### PR TITLE
[#71] LocalNotificationClient 구현

### DIFF
--- a/Soomsil-USaint/Application/AppReducer.swift
+++ b/Soomsil-USaint/Application/AppReducer.swift
@@ -39,8 +39,8 @@ struct AppReducer {
             case .backgroundTask:
                 debugPrint("AppReducer: backgroundTask")
                 return .run { send in
-                    @Shared(.appStorage("permission")) var permission = true
-                    try await localNotificationClient.setLecturePushNotification("\(permission)")
+                    @Shared(.appStorage("isFirst")) var isFirst = true
+                    try await localNotificationClient.setLecturePushNotification("\(isFirst)")
                 }
             default:
                 return .none

--- a/Soomsil-USaint/Application/AppReducer.swift
+++ b/Soomsil-USaint/Application/AppReducer.swift
@@ -12,10 +12,10 @@ import ComposableArchitecture
 @Reducer
 struct AppReducer {
     @ObservableState
-    enum State: Equatable {
+    enum State {
         case initial
         case loggedOut
-        case loggedIn
+        case loggedIn(HomeReducer.State)
         
         init() {
             self = .initial
@@ -24,15 +24,21 @@ struct AppReducer {
     
     enum Action {
         case initialize
+        case home(HomeReducer.Action)
     }
     
     var body: some Reducer<State, Action> {
         Reduce { state, action in
             switch action {
             case .initialize:
-                state = .loggedOut
+                state = .loggedIn(HomeReducer.State())
+                return .none
+            default:
                 return .none
             }
+        }
+        .ifCaseLet(\.loggedIn, action: \.home) {
+            HomeReducer()
         }
     }
 }

--- a/Soomsil-USaint/Application/AppReducer.swift
+++ b/Soomsil-USaint/Application/AppReducer.swift
@@ -24,8 +24,11 @@ struct AppReducer {
     
     enum Action {
         case initialize
+        case backgroundTask
         case home(HomeReducer.Action)
     }
+    
+    @Dependency(\.localNotificationClient) var localNotificationClient
     
     var body: some Reducer<State, Action> {
         Reduce { state, action in
@@ -33,6 +36,12 @@ struct AppReducer {
             case .initialize:
                 state = .loggedIn(HomeReducer.State())
                 return .none
+            case .backgroundTask:
+                return .run { send in
+                    @Shared(.appStorage("isFirstTest2")) var isFirst = true
+                    print("App - \(isFirst)")
+                    try await localNotificationClient.setLecturePushNotification("\(isFirst)")
+                }
             default:
                 return .none
             }

--- a/Soomsil-USaint/Application/AppReducer.swift
+++ b/Soomsil-USaint/Application/AppReducer.swift
@@ -37,10 +37,10 @@ struct AppReducer {
                 state = .loggedIn(HomeReducer.State())
                 return .none
             case .backgroundTask:
+                debugPrint("AppReducer: backgroundTask")
                 return .run { send in
-                    @Shared(.appStorage("isFirstTest2")) var isFirst = true
-                    print("App - \(isFirst)")
-                    try await localNotificationClient.setLecturePushNotification("\(isFirst)")
+                    @Shared(.appStorage("permission")) var permission = true
+                    try await localNotificationClient.setLecturePushNotification("\(permission)")
                 }
             default:
                 return .none

--- a/Soomsil-USaint/Application/AppView.swift
+++ b/Soomsil-USaint/Application/AppView.swift
@@ -28,7 +28,9 @@ struct AppView: View {
                     }
                 }
         case .loggedIn:
-            HomeView(viewModel: DefaultSaintHomeViewModel(), isLoggedIn: $isLoggedIn)
+            if let store = store.scope(state: \.loggedIn, action: \.home) {
+                HomeView(store: store, viewModel: DefaultSaintHomeViewModel(), isLoggedIn: $isLoggedIn)
+            }
         case .loggedOut:
             LoginView(isLoggedIn: $isLoggedIn)
         }

--- a/Soomsil-USaint/Application/AppView.swift
+++ b/Soomsil-USaint/Application/AppView.swift
@@ -21,7 +21,7 @@ struct AppView: View {
             SplashView()
                 .task {
                     do {
-                        try await Task.sleep(for: .seconds(3))
+                        try await Task.sleep(for: .seconds(2))
                         store.send(.initialize)
                     } catch {
                         print(error.localizedDescription)

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -5,3 +5,32 @@
 //  Created by 이조은 on 1/6/25.
 //
 
+import Foundation
+
+import ComposableArchitecture
+
+@Reducer
+struct HomeReducer {
+    @ObservableState
+    struct State {
+        @Shared(.appStorage("isFirstTest")) var isFirst = true
+    }
+    
+    enum Action {
+        case onAppear
+    }
+    
+    @Dependency(\.localNotificationClient) var localNotificationClient
+    
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                debugPrint("Before: \(state.isFirst)")
+                state.$isFirst.withLock { $0 = false }
+                debugPrint("After: \(state.isFirst)")
+                return .none
+            }
+        }
+    }
+}

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -13,7 +13,7 @@ import ComposableArchitecture
 struct HomeReducer {
     @ObservableState
     struct State {
-        @Shared(.appStorage("isFirstTest")) var isFirst = true
+        @Shared(.appStorage("isFirstTest2")) var isFirst = true
     }
     
     enum Action {
@@ -26,9 +26,9 @@ struct HomeReducer {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                debugPrint("Before: \(state.isFirst)")
+                debugPrint("Home - Before: \(state.isFirst)")
                 state.$isFirst.withLock { $0 = false }
-                debugPrint("After: \(state.isFirst)")
+                debugPrint("Home - After: \(state.isFirst)")
                 return .none
             }
         }

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -61,13 +61,12 @@ struct HomeView<VM: HomeViewModel>: View {
                 }
                 .background(.white)
                 .onAppear {
-                    if !isFirst {
-                        LocalNotificationManager().requestAuthorization(completion: { _ in
-                        })
-                        LocalNotificationManager.shared.saveIsFirst(true)
-                    }
                     store.send(.onAppear)
-
+//                    if !isFirst {
+//                        LocalNotificationManager().requestAuthorization(completion: { _ in
+//                        })
+//                        LocalNotificationManager.shared.saveIsFirst(true)
+//                    }
                 }
 //                .task {
 //                    await loadUserInfoAndTotalReposrtCard()

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -69,9 +69,9 @@ struct HomeView<VM: HomeViewModel>: View {
                     store.send(.onAppear)
 
                 }
-                .task {
-                    await loadUserInfoAndTotalReposrtCard()
-                }
+//                .task {
+//                    await loadUserInfoAndTotalReposrtCard()
+//                }
                 .registerYDSToast()
                 .animation(.easeInOut, value: viewModel.isLogedIn())
                 .navigationDestination(for: StackView.self) { stackView in

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -6,16 +6,20 @@
 //
 
 import SwiftUI
-import YDS_SwiftUI
+
+import ComposableArchitecture
 import Rusaint
+import YDS_SwiftUI
 
 // swiftlint:disable identifier_name
 
 struct HomeView<VM: HomeViewModel>: View {
+    @Perception.Bindable var store: StoreOf<HomeReducer>
+    
     @State var path: [StackView] = []
     @StateObject var viewModel: VM
 
-    @State var isLaunching: Bool = true
+//    @State var isLaunching: Bool = true
     @Binding var isLoggedIn: Bool
     @State var isFirst: Bool = LocalNotificationManager.shared.getIsFirst()
     @State private var session: USaintSession?
@@ -23,19 +27,19 @@ struct HomeView<VM: HomeViewModel>: View {
     @State private var isLatestSemesterNotYetConfirmed: Bool = true
 
     var body: some View {
-        if isLaunching {
-            SplashView()
-                .onAppear() {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        isLaunching = false
-                    }
-                }
-        }
-        else if !isLoggedIn {
-            NavigationStack {
-                LoginView(isLoggedIn: $isLoggedIn)
-            }
-        } else {
+//        if isLaunching {
+//            SplashView()
+//                .onAppear() {
+//                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+//                        isLaunching = false
+//                    }
+//                }
+//        }
+//        else if !isLoggedIn {
+//            NavigationStack {
+//                LoginView(isLoggedIn: $isLoggedIn)
+//            }
+//        } else {
             NavigationStack(path: $path) {
                 VStack {
                     HStack {
@@ -62,6 +66,7 @@ struct HomeView<VM: HomeViewModel>: View {
                         })
                         LocalNotificationManager.shared.saveIsFirst(true)
                     }
+                    store.send(.onAppear)
 
                 }
                 .task {
@@ -84,7 +89,7 @@ struct HomeView<VM: HomeViewModel>: View {
                     }
                 }
             }
-        }
+//        }
     }
 
     private func loadUserInfoAndTotalReposrtCard() async {

--- a/Soomsil-USaint/Application/Rusaint_iOSApp.swift
+++ b/Soomsil-USaint/Application/Rusaint_iOSApp.swift
@@ -18,6 +18,7 @@ struct Rusaint_iOSApp: App {
 //    let viewModel = DefaultSaintHomeViewModel()
 //    @State private var isLoggedIn: Bool = HomeRepository.shared.hasCachedUserInformation
 //    @State private var notificationPermission: Bool = false
+    let store = Store(initialState: AppReducer.State()) { AppReducer() }
 
     var body: some Scene {
         WindowGroup {
@@ -31,7 +32,15 @@ struct Rusaint_iOSApp: App {
 //                        }
 //                    }
 //                }
-            AppView(store: Store(initialState: AppReducer.State()) { AppReducer() })
+            VStack {
+                Button("Test") {
+                    scheduleCurrentSemester()
+                }
+                AppView(store: store)
+            }
+        }
+        .backgroundTask(.appRefresh("soomsilUSaint.com")) {
+            await store.send(.backgroundTask)
         }
 //        .backgroundTask(.appRefresh("soomsilUSaint.com")) {
 //            notificationPermission = LocalNotificationManager.shared.getNotificationPermission()

--- a/Soomsil-USaint/Application/Rusaint_iOSApp.swift
+++ b/Soomsil-USaint/Application/Rusaint_iOSApp.swift
@@ -14,7 +14,7 @@ import Rusaint
 @main
 struct Rusaint_iOSApp: App {
 
-//    @Environment(\.scenePhase) var scenePhase
+    @Environment(\.scenePhase) var scenePhase
 //    let viewModel = DefaultSaintHomeViewModel()
 //    @State private var isLoggedIn: Bool = HomeRepository.shared.hasCachedUserInformation
 //    @State private var notificationPermission: Bool = false
@@ -32,15 +32,17 @@ struct Rusaint_iOSApp: App {
 //                        }
 //                    }
 //                }
-            VStack {
-                Button("Test") {
-                    scheduleCurrentSemester()
+            AppView(store: store)
+                .onChange(of: scenePhase) { phase in
+                    debugPrint("ScenePhase: \(phase)")
+                    if phase == .background {
+                        scheduleCurrentSemester()
+                    }
                 }
-                AppView(store: store)
-            }
         }
         .backgroundTask(.appRefresh("soomsilUSaint.com")) {
-            await store.send(.backgroundTask)
+            LocalNotificationManager.shared.pushLectureNotification(lectureTitle: "Test2")
+//            await store.send(.backgroundTask)
         }
 //        .backgroundTask(.appRefresh("soomsilUSaint.com")) {
 //            notificationPermission = LocalNotificationManager.shared.getNotificationPermission()
@@ -61,7 +63,7 @@ func scheduleCurrentSemester() {
 
     do {
         try BGTaskScheduler.shared.submit(request)
-        print("")
+        print("Scheduler Scheduled")
     } catch(let error) {
         print("Scheduler Error: \(error)")
     }

--- a/Soomsil-USaint/Application/Rusaint_iOSApp.swift
+++ b/Soomsil-USaint/Application/Rusaint_iOSApp.swift
@@ -41,8 +41,7 @@ struct Rusaint_iOSApp: App {
                 }
         }
         .backgroundTask(.appRefresh("soomsilUSaint.com")) {
-            LocalNotificationManager.shared.pushLectureNotification(lectureTitle: "Test2")
-//            await store.send(.backgroundTask)
+            await store.send(.backgroundTask)
         }
 //        .backgroundTask(.appRefresh("soomsilUSaint.com")) {
 //            notificationPermission = LocalNotificationManager.shared.getNotificationPermission()

--- a/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
@@ -36,7 +36,7 @@ extension LocalNotificationClient: DependencyKey {
             content.body = "[\(lectureTitle)] 과목의 성적이 공개되었어요."
             content.sound = .default
             
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 2, repeats: false)
             let request = UNNotificationRequest(identifier: lectureTitle, content: content, trigger: trigger)
             
             try await UNUserNotificationCenter.current().add(request)

--- a/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
@@ -10,9 +10,6 @@ import UIKit
 import ComposableArchitecture
 
 struct LocalNotificationClient {
-    // TODO: 논의가 필요한 부분 -> UserDefaults 대신 @Shared를 통해 permission과 isFirst를 사용하는 것이 어떤가요?
-    // isFirst는 Home에서만 사용해서 옮기는 것도 가능하지만, permission은 Home, Setting, backgroundTask에서 사용하니까 일단 전역으로 두는게 좋을까요?
-    
     var requestPushAuthorization: @Sendable () async throws -> Bool
     var getPushAuthorizationStatus: @Sendable () async -> Bool
     var setLecturePushNotification: @Sendable (String) async throws -> Void
@@ -56,13 +53,5 @@ extension LocalNotificationClient: DependencyKey {
         }
     )
     
-    static let testValue: LocalNotificationClient = Self(
-        requestPushAuthorization: {
-            return true
-        }, getPushAuthorizationStatus: {
-            return true
-        }, setLecturePushNotification: { lectureTitle in
-            debugPrint(lectureTitle)
-        }
-    )
+    static let testValue: LocalNotificationClient = previewValue
 }

--- a/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
@@ -5,3 +5,25 @@
 //  Created by 이조은 on 1/6/25.
 //
 
+import UIKit
+
+import ComposableArchitecture
+
+struct LocalNotificationClient {
+    
+}
+
+extension DependencyValues {
+    var localNotificationClient: LocalNotificationClient {
+        get { self[LocalNotificationClient.self] }
+        set { self[LocalNotificationClient.self] = newValue }
+    }
+}
+
+extension LocalNotificationClient: DependencyKey {
+    static let liveValue: LocalNotificationClient = Self()
+    
+    static let previewValue: LocalNotificationClient = Self()
+    
+    static let testValue: LocalNotificationClient = Self()
+}

--- a/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
@@ -10,7 +10,12 @@ import UIKit
 import ComposableArchitecture
 
 struct LocalNotificationClient {
+    // TODO: 논의가 필요한 부분 -> UserDefaults 대신 @Shared를 통해 permission과 isFirst를 사용하는 것이 어떤가요?
+    // isFirst는 Home에서만 사용해서 옮기는 것도 가능하지만, permission은 Home, Setting, backgroundTask에서 사용하니까 일단 전역으로 두는게 좋을까요?
     
+    var requestPushAuthorization: @Sendable () async throws -> Bool
+    var getPushAuthorizationStatus: @Sendable () async -> Bool
+    var setLecturePushNotification: @Sendable (String) async throws -> Void
 }
 
 extension DependencyValues {
@@ -21,9 +26,43 @@ extension DependencyValues {
 }
 
 extension LocalNotificationClient: DependencyKey {
-    static let liveValue: LocalNotificationClient = Self()
+    static let liveValue: LocalNotificationClient = Self(
+        requestPushAuthorization: {
+            return try await UNUserNotificationCenter.current()
+                .requestAuthorization(options: [.alert, .badge, .sound])
+        }, getPushAuthorizationStatus: {
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            return (settings.authorizationStatus == .authorized) || (settings.authorizationStatus == .provisional)
+        }, setLecturePushNotification: { lectureTitle in
+            let content = UNMutableNotificationContent()
+            content.title = "숨쉴때 유세인트"
+            content.body = "[\(lectureTitle)] 과목의 성적이 공개되었어요."
+            content.sound = .default
+            
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+            let request = UNNotificationRequest(identifier: lectureTitle, content: content, trigger: trigger)
+            
+            try await UNUserNotificationCenter.current().add(request)
+        }
+    )
     
-    static let previewValue: LocalNotificationClient = Self()
+    static let previewValue: LocalNotificationClient = Self(
+        requestPushAuthorization: {
+            return true
+        }, getPushAuthorizationStatus: {
+            return true
+        }, setLecturePushNotification: { lectureTitle in
+            debugPrint(lectureTitle)
+        }
+    )
     
-    static let testValue: LocalNotificationClient = Self()
+    static let testValue: LocalNotificationClient = Self(
+        requestPushAuthorization: {
+            return true
+        }, getPushAuthorizationStatus: {
+            return true
+        }, setLecturePushNotification: { lectureTitle in
+            debugPrint(lectureTitle)
+        }
+    )
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
앱 내에서 푸시 알림 관련 퍼미션과 푸시 알림 전송을 담당하는 LocalNotificationClient를 구현

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #71
- 피그마 : 
- 관련 문서 :
- close: #71

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
1. LocalNotificationClient 구현
- 배경: 기존 LocalNotificationManager를 TCA에서 DI를 위한 struct 변경 및 Dependency Key와 Value 선언 및 구현

- 변경점: 기존 Manager에서 메서드명을 일부 변경, completion handler가 아닌 async await으로 로직 수정, UserDefauls 관련 로직 제거

2. UserDefauls 이전
- 배경: 해당 Client는 푸시 알림 퍼미션과 전송 관련 로직만 들고 있는 것이 적절하다고 생각해서, 기존 LocalNotificationManager와 동일하게 UserDefaults를 통해 처음 앱에 접속했는지, 퍼미션을 받았는지 여부를 get/set 하는 것이 적절하지 않다고 생각

그리고, 필요할 때 직접 권한을 확인하는 것이 UserDefaults를 통해 들고 있는 것보다 코드나 로직이 안정적이라고 생각

하지만, 리팩토링의 목표가 현재 로직은 최대한 그대로 두고, 아키텍쳐만 바꾸는 것이므로, isFirst와 permission은 유지하되, 리팩토링 이후 변경 또는 삭제에 대해 논의해보기로 결정

- 결론: isFirst는 HomeReducer에서만 사용하기 때문에 `@Shared(.appStorage("isFirst))`를 통해 SwiftUI의 `@AppStorage`와 비슷하게 관리하고, permission은 HomeReducer와 SettingReducer에서 위와 동일한 방식으로, 공유 자원에 접근해서 사용

하지만, permission의 경우 BackgroundTask에서도 접근해서 사용하기 때문에, 여기에서도 접근 가능 여부에 대한 테스트를 진행, 공유자원과 동일한 결과(false)와 실행이 가능한 것을 확인
더 다양한 케이스에 대해 테스트는 필요

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

`@Shared` 관련 문서
https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/sharingstate/
`withLock` 관련 마이그레이션 문서
https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/migratingto1.11

## 🔥 Test
<!-- Test -->
1. 홈화면에서 LocalNotificationClient를 통한 푸시 알림 테스트
<img width=200 src=https://github.com/user-attachments/assets/274fc11f-182d-4181-b0f5-fedf8cb654fa />

2. 백그라운드에서 푸시 알림 및 공유 자원 테스트
<img width=200 src=https://github.com/user-attachments/assets/b6493747-12f5-4483-9edd-fa4192acf643 />
