### PR TITLE
[#85] NSManagedObjectContext Extension 추가

### DIFF
--- a/Soomsil-USaint/Data/Client/RuSaint/GradeClient.swift
+++ b/Soomsil-USaint/Data/Client/RuSaint/GradeClient.swift
@@ -18,8 +18,8 @@ struct GradeClient {
     var fetchGrades: @Sendable (_ year: Int, _ semester: SemesterType) async throws -> [ClassGrade]
 
     var getTotalReportCard: @Sendable () async throws -> TotalReportCard
-    var getAllSemesterGrades: () async throws -> [CDSemester]
-    var getGrades: (_ year: Int, _ semester: String) async throws -> CDSemester?
+    var getAllSemesterGrades: () async throws -> [GradeSummary]
+    var getGrades: (_ year: Int, _ semester: String) async throws -> GradeSummary?
     var updateTotalReportCard: @Sendable (_ totalReportCard: TotalReportCard) async throws -> Void
     var updateAllSemesterGrades: (_ rusaintSemesterGrades: [GradeSummary]) async throws -> Void
     var updateGrades: (_ year: Int, _ semester: String, _ newLectures: [LectureDetail]) async throws -> Void
@@ -90,7 +90,7 @@ extension GradeClient: DependencyKey {
                 let fetchRequest: NSFetchRequest<CDSemester> = CDSemester.fetchRequest()
 
                 let fetchedEntity = try context.fetch(fetchRequest)
-                return fetchedEntity
+                return fetchedEntity.toGradeSummaryModel()
             },
             getGrades: { year, semester in
                 let context = coreDataStack.taskContext()
@@ -101,7 +101,7 @@ extension GradeClient: DependencyKey {
                 ])
 
                 if let fetchedEntity = try? context.fetch(fetchRequest).first {
-                    return fetchedEntity
+                    return fetchedEntity.toGradeSummaryModel()
                 } else {
                     return nil
                 }
@@ -257,10 +257,11 @@ extension GradeClient: DependencyKey {
             TotalReportCard(gpa: 4.34, earnedCredit: 108, graduateCredit: 133)
         }, getAllSemesterGrades: {
             [
-                CDSemester()
+                GradeSummary(year: 2024, semester: "2 학기", gpa: 4.5, earnedCredit: 133, semesterRank: 11, semesterStudentCount: 100, overallRank: 22, overallStudentCount: 22, lectures: [LectureDetail(code: "202", title: "기업가정신", credit: 3.0, score: "4.0", grade: .aZero, professorName: "최지우")]),
+                 GradeSummary(year: 2024, semester: "1 학기", gpa: 4.5, earnedCredit: 133, semesterRank: 11, semesterStudentCount: 100, overallRank: 22, overallStudentCount: 22, lectures: [LectureDetail(code: "202", title: "기업가정신", credit: 3.0, score: "4.0", grade: .aZero, professorName: "이조은")])
             ]
         }, getGrades: { year, semester in
-            CDSemester()
+            GradeSummary(year: 2024, semester: "2 학기", gpa: 4.5, earnedCredit: 133, semesterRank: 11, semesterStudentCount: 100, overallRank: 22, overallStudentCount: 22, lectures: [LectureDetail(code: "202", title: "기업가정신", credit: 3.0, score: "4.0", grade: .aZero, professorName: "최지우")])
         }, updateTotalReportCard: { totalReportCard in
             return
         }, updateAllSemesterGrades: { rusaintSemesterGrades in

--- a/Soomsil-USaint/Data/Client/RuSaint/GradeClient.swift
+++ b/Soomsil-USaint/Data/Client/RuSaint/GradeClient.swift
@@ -107,7 +107,7 @@ extension GradeClient: DependencyKey {
                 }
             }, updateTotalReportCard: { totalReportCard in
                 let context = coreDataStack.taskContext()
-                createTotalReportCard(gpa: totalReportCard.gpa, earnedCredit: totalReportCard.earnedCredit, graduateCredit: Float(totalReportCard.graduateCredit), in: context)
+                context.createTotalReportCard(gpa: totalReportCard.gpa, earnedCredit: totalReportCard.earnedCredit, graduateCredit: Float(totalReportCard.graduateCredit))
 
                 context.performAndWait {
                     do {
@@ -123,7 +123,7 @@ extension GradeClient: DependencyKey {
                 try context.execute(deleteRequest)
 
                 for grade in grades {
-                    createSemester(year: grade.year,
+                    context.createSemester(year: grade.year,
                                    semester: grade.semester,
                                    gpa: grade.gpa,
                                    earnedCredit: grade.earnedCredit,
@@ -131,8 +131,7 @@ extension GradeClient: DependencyKey {
                                    semesterStudentCount: grade.semesterStudentCount,
                                    overallRank: grade.overallRank,
                                    overallStudentCount: grade.overallStudentCount,
-                                   lectures: grade.lectures ?? nil,
-                                   in: context)
+                                   lectures: grade.lectures ?? nil)
                 }
                 try context.save()
             },
@@ -185,7 +184,8 @@ extension GradeClient: DependencyKey {
             addGrades: { newSemester in
                 let context = coreDataStack.taskContext()
 
-                createSemester(year: newSemester.year,
+
+                context.createSemester(year: newSemester.year,
                                semester: newSemester.semester,
                                gpa: newSemester.gpa,
                                earnedCredit: newSemester.earnedCredit,
@@ -193,8 +193,7 @@ extension GradeClient: DependencyKey {
                                semesterStudentCount: newSemester.semesterStudentCount,
                                overallRank: newSemester.overallRank,
                                overallStudentCount: newSemester.overallStudentCount,
-                               lectures: newSemester.lectures ?? nil,
-                               in: context)
+                               lectures: newSemester.lectures ?? nil)
 
                 try context.save()
             },
@@ -227,53 +226,6 @@ extension GradeClient: DependencyKey {
                 try context.save()
             }
         )
-
-        func createSemester(
-            year: Int,
-            semester: String,
-            gpa: Float,
-            earnedCredit: Float,
-            semesterRank: Int,
-            semesterStudentCount: Int,
-            overallRank: Int,
-            overallStudentCount: Int,
-            lectures: [LectureDetail]?,
-            in context: NSManagedObjectContext
-        ) {
-            let semesterEntity = CDSemester(context: context)
-            semesterEntity.year = Int16(year)
-            semesterEntity.semester = semester
-            semesterEntity.gpa = gpa
-            semesterEntity.earnedCredit = earnedCredit
-            semesterEntity.semesterRank = Int16(semesterRank)
-            semesterEntity.semesterStudentCount = Int16(semesterStudentCount)
-            semesterEntity.overallRank = Int16(overallRank)
-            semesterEntity.overallStudentCount = Int16(overallStudentCount)
-
-            let lectureEntities = lectures?.compactMap { lecture -> CDLecture? in
-                let cdLecture = CDLecture(context: context)
-                cdLecture.code = lecture.code
-                cdLecture.title = lecture.title
-                cdLecture.credit = Float(lecture.credit)
-                cdLecture.score = lecture.score
-                cdLecture.grade = lecture.grade.rawValue
-                cdLecture.professorName = lecture.professorName
-                return cdLecture
-            }
-            lectureEntities?.forEach { semesterEntity.addToLectures($0) }
-        }
-
-        func createTotalReportCard(
-            gpa: Float,
-            earnedCredit: Float,
-            graduateCredit: Float,
-            in context: NSManagedObjectContext
-        ) {
-            let detail = CDTotalReportCard(context: context)
-            detail.gpa = gpa
-            detail.earnedCredit = earnedCredit
-            detail.graduateCredit = graduateCredit
-        }
     }()
 
     static let previewValue: GradeClient = Self(

--- a/Soomsil-USaint/Global/Utils/Extension/NSManagedObjectContext+.swift
+++ b/Soomsil-USaint/Global/Utils/Extension/NSManagedObjectContext+.swift
@@ -1,0 +1,51 @@
+//
+//  CDTotalReportCard+.swift
+//  Soomsil-USaint
+//
+//  Created by 이조은 on 2/3/25.
+//
+
+import CoreData
+
+extension NSManagedObjectContext {
+    func createTotalReportCard(gpa: Float, earnedCredit: Float, graduateCredit: Float) {
+        let detail = CDTotalReportCard(context: self)
+        detail.gpa = gpa
+        detail.earnedCredit = earnedCredit
+        detail.graduateCredit = graduateCredit
+    }
+
+    func createSemester(
+        year: Int,
+        semester: String,
+        gpa: Float,
+        earnedCredit: Float,
+        semesterRank: Int,
+        semesterStudentCount: Int,
+        overallRank: Int,
+        overallStudentCount: Int,
+        lectures: [LectureDetail]?
+    ) {
+        let semesterEntity = CDSemester(context: self)
+        semesterEntity.year = Int16(year)
+        semesterEntity.semester = semester
+        semesterEntity.gpa = gpa
+        semesterEntity.earnedCredit = earnedCredit
+        semesterEntity.semesterRank = Int16(semesterRank)
+        semesterEntity.semesterStudentCount = Int16(semesterStudentCount)
+        semesterEntity.overallRank = Int16(overallRank)
+        semesterEntity.overallStudentCount = Int16(overallStudentCount)
+
+        let lectureEntities = lectures?.compactMap { lecture -> CDLecture? in
+            let cdLecture = CDLecture(context: self)
+            cdLecture.code = lecture.code
+            cdLecture.title = lecture.title
+            cdLecture.credit = Float(lecture.credit)
+            cdLecture.score = lecture.score
+            cdLecture.grade = lecture.grade.rawValue
+            cdLecture.professorName = lecture.professorName
+            return cdLecture
+        }
+        lectureEntities?.forEach { semesterEntity.addToLectures($0) }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- GradeClient에 있는 create000 함수들을 NSManagedObjectContext+ 파일에 정리해주었습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #85 
- 피그마 : 
- 관련 문서 :
- close: #85 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 모델 파일을 살펴보면 다양한 Extension들이 정의되어 있지만, 일단은 해당 모델에만 관련이 있는 익스텐션이기 때문에 따로 정리해두지 않고 모델 파일 하단에 두려고합니다. 추후에 리팩토링이 완료되면 그때 Extension으로 빼둘 코드를 다시 정리해보는 것도 좋을 것 같습니다!

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
> #### NSManagedObjectContext은 무엇일까요?
>연관된 모델 객체 그룹을 포함하는 컨텍스트이며, 하나 이상의 영구 저장소와 내부적으로 일관된 뷰를 유지합니다. 관리 객체에 대한 변경 사항은 메모리에 유지되면, Core Data가 해당 컨텍스트를 저장하기 전까지는(`context.save()`) 영구 저장소에 반영되지 않습니다.
[공식문서](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext)


## 🔥 Test
<!-- Test -->
