### PR TITLE
[#84] SettingView 내 ListView 분리 및 추가 리팩터링

### DIFF
--- a/Soomsil-USaint/Application/AppReducer.swift
+++ b/Soomsil-USaint/Application/AppReducer.swift
@@ -66,7 +66,7 @@ struct AppReducer {
             case .login(.loginResponse(.success(let (info, report)))):
                 state = .loggedIn(HomeReducer.State(studentInfo: info, totalReportCard: report))
                 return .none
-            case .home(.path(.element(id: _, action: .setting(.alert(.presented(.logout)))))):
+            case .home(.path(.element(id: _, action: .setting(.alert(.presented(.confirmLogoutTapped)))))):
                 state = .loggedOut(LoginReducer.State())
                 return .none
             default:

--- a/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
@@ -44,9 +44,7 @@ struct SettingReducer {
         Reduce { state, action in
             switch action {
             case .onAppear:
-                if let info: [String: Any] = Bundle.main.infoDictionary,
-                   let currentVersion: String
-                    = info["CFBundleShortVersionString"] as? String {
+                if let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
                     state.appVersion = currentVersion
                 }
                 return .none

--- a/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
@@ -16,8 +16,6 @@ struct SettingReducer {
     struct State {
         @Shared(.appStorage("permission")) var permission = false
         @Presents var alert: AlertState<Action.Alert>?
-//        var path = StackState<Path.State>()
-//        var appState: AppReducer.State?
     }
     
     enum Action: BindableAction {
@@ -28,9 +26,7 @@ struct SettingReducer {
         case requestPushAuthorizationResponse(Result<Bool, Error>)
         case termsOfServiceButtonTapped
         case privacyPolicyButtonTapped
-//        case path(StackActionOf<Path>)
         case alert(PresentationAction<Alert>)
-//        case appState(AppReducer.Action)
         
         enum Alert: Equatable {
             case logout
@@ -110,30 +106,10 @@ struct SettingReducer {
                         try await localNotificationClient.requestPushAuthorization()
                     }))
                 }
-//            case .termsOfServiceButtonTapped:
-//                state.path.append(
-//                    .navigateToTermsWebView(WebReducer.State(
-//                        url: URL(string: "https://auth.yourssu.com/terms/service.html")!)))
-//                return .none
-//            case .privacyPolicyButtonTapped:
-//                state.path.append(.navigateToTermsWebView(WebReducer.State(
-//                    url: URL(string: "https://auth.yourssu.com/terms/information.html")!)))
-//                return .none
             default:
                 return .none
             }
         }
-//        .ifLet(\.appState, action: \.appState) {
-//            AppReducer()
-//        }
         .ifLet(\.$alert, action: \.alert)
-//        .forEach(\.path, action: \.path)
     }
 }
-
-//extension SettingReducer {
-//    @Reducer
-//    enum Path {
-//        case navigateToTermsWebView(WebReducer)
-//    }
-//}

--- a/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
@@ -66,6 +66,7 @@ struct SettingReducer {
                 }
             case .togglePushAuthorization(false):
                 state.$permission.withLock { $0 = false }
+                YDSToast("알림권한 거부", haptic: .success)
                 return .none
             case .pushAuthorizationResponse(.success(let granted)):
                 state.$permission.withLock { $0 = granted }

--- a/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
@@ -29,8 +29,8 @@ struct SettingReducer {
         case alert(PresentationAction<Alert>)
         
         enum Alert: Equatable {
-            case logout
-            case configurePushAuthorization
+            case confirmLogoutTapped
+            case configurePushAuthorizationTapped
         }
     }
     
@@ -46,7 +46,7 @@ struct SettingReducer {
                 } actions: {
                     ButtonState(
                         role: .destructive,
-                        action: .logout) {
+                        action: .confirmLogoutTapped) {
                             TextState("로그아웃")
                         }
                     ButtonState(
@@ -55,7 +55,7 @@ struct SettingReducer {
                         }
                 }
                 return .none
-            case .alert(.presented(.logout)):
+            case .alert(.presented(.confirmLogoutTapped)):
                 YDSToast("로그아웃 완료", haptic: .success)
                 return .none
             case .togglePushAuthorization(true):
@@ -75,7 +75,7 @@ struct SettingReducer {
                     } actions: {
                         ButtonState(
                             role: .destructive,
-                            action: .configurePushAuthorization
+                            action: .configurePushAuthorizationTapped
                         ) {
                             TextState("설정")
                         }
@@ -101,7 +101,7 @@ struct SettingReducer {
                     }
                 }
                 return .none
-            case .alert(.presented(.configurePushAuthorization)):
+            case .alert(.presented(.configurePushAuthorizationTapped)):
                 debugPrint("alert permission")
                 return .run { send in
                     await send(.requestPushAuthorizationResponse(Result {

--- a/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
@@ -16,10 +16,13 @@ struct SettingReducer {
     struct State {
         @Shared(.appStorage("permission")) var permission = false
         @Presents var alert: AlertState<Action.Alert>?
+        
+        var appVersion: String = "-"
     }
     
     enum Action: BindableAction {
         case binding(BindingAction<State>)
+        case onAppear
         case logoutButtonTapped
         case togglePushAuthorization(Bool)
         case pushAuthorizationResponse(Result<Bool, Error>)
@@ -40,6 +43,13 @@ struct SettingReducer {
         BindingReducer()
         Reduce { state, action in
             switch action {
+            case .onAppear:
+                if let info: [String: Any] = Bundle.main.infoDictionary,
+                   let currentVersion: String
+                    = info["CFBundleShortVersionString"] as? String {
+                    state.appVersion = currentVersion
+                }
+                return .none
             case .logoutButtonTapped:
                 state.alert = AlertState {
                     TextState("로그아웃 하시겠습니까?")

--- a/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
@@ -56,7 +56,7 @@ struct SettingReducer {
                 }
                 return .none
             case .alert(.presented(.logout)):
-//                YDSToast("로그아웃", haptic: .success)
+                YDSToast("로그아웃 완료", haptic: .success)
                 return .none
             case .togglePushAuthorization(true):
                 return .run { send in
@@ -86,6 +86,8 @@ struct SettingReducer {
                     } message: {
                         TextState("알림에 대한 권한 사용을 거부하였습니다. 기능 사용을 원하실 경우 설정 > 앱 > 숨쉴때 유세인트 > 알림 권한 허용을 해주세요.")
                     }
+                } else {
+                    YDSToast("알림권한 허용", haptic: .success)
                 }
                 return .none
             case .requestPushAuthorizationResponse(.success(let granted)):

--- a/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
@@ -26,14 +26,10 @@ struct ListRowView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(title)
-                .font(YDSFont.subtitle3)
+                .font(.system(size: 14, weight: .bold))
                 .foregroundColor(YDSColor.textSecondary)
                 .padding(20)
                 .frame(height: 48)
-            
-            Divider()
-                .frame(height: 0.34)
-                .background(YDSColor.borderThin)
             
             ForEach(items.indices, id: \.self) { index in
                 HStack {

--- a/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
@@ -54,7 +54,7 @@ struct ItemModel: View {
                 .padding(20)
                 .frame(height: 48)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(isPressed ? Color(red: 0.95, green: 0.96, blue: 0.97) : Color.clear)
+                .background(isPressed ? Color(red: 0.95, green: 0.96, blue: 0.97) : Color.white)
                 .gesture(
                     DragGesture(minimumDistance: 0)
                         .onChanged { _ in isPressed = true }

--- a/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
@@ -60,7 +60,12 @@ struct ItemModel: View {
                         .onChanged { _ in isPressed = true }
                         .onEnded { _ in
                             isPressed = false
-                            action()
+                            switch rightItem {
+                            case .none:
+                                action()
+                            case .toggle(let isPushAuthorizationEnabled):
+                                return
+                            }
                         }
                 )
             
@@ -75,6 +80,12 @@ struct ItemModel: View {
                     .tint(YDSColor.buttonPoint)
                     .frame(height: 48)
                     // TODO: onChange 액션 추가
+                    .onChange(of: isPushAuthorizationEnabled) {
+                        action()
+                    }
+//                    .onReceive(isPushAuthorizationEnabled.projectedValue) { newValue in
+//                                action()
+//                            }
             }
         }
     }

--- a/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
@@ -31,6 +31,10 @@ struct ListRowView: View {
                 .padding(20)
                 .frame(height: 48)
             
+            Divider()
+                .frame(height: 0.34)
+                .background(YDSColor.borderThin)
+            
             ForEach(items.indices, id: \.self) { index in
                 HStack {
                     items[index]

--- a/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
@@ -1,0 +1,81 @@
+//
+//  ListRowView.swift
+//  Soomsil-USaint
+//
+//  Created by 최지우 on 2/5/25.
+//
+
+import SwiftUI
+
+import YDS_SwiftUI
+
+enum RightItem {
+    case none
+    case toggle(isPushAuthorizationEnabled: Binding<Bool>)
+}
+
+struct ListRowView: View {
+    let title: String
+    let items: [ItemModel]
+        
+    init(title: String, items: [ItemModel]) {
+        self.title = title
+        self.items = items
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .font(YDSFont.subtitle3)
+                .foregroundColor(YDSColor.textSecondary)
+                .padding(20)
+                .frame(height: 48)
+            
+            ForEach(items.indices, id: \.self) { index in
+                HStack {
+                    items[index]
+                }
+            }
+        }
+    }
+}
+
+struct ItemModel: View {
+    let text: String
+    let rightItem: RightItem
+    let action: () -> Void
+    @State private var isPressed: Bool = false
+    
+    var body: some View {
+        HStack {
+            Text(text)
+                .font(YDSFont.button3)
+                .foregroundColor(YDSColor.textSecondary)
+                .padding(20)
+                .frame(height: 48)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(isPressed ? Color(red: 0.95, green: 0.96, blue: 0.97) : Color.clear)
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { _ in isPressed = true }
+                        .onEnded { _ in
+                            isPressed = false
+                            action()
+                        }
+                )
+            
+            switch rightItem {
+            case .none:
+                EmptyView()
+            case .toggle(let isPushAuthorizationEnabled):
+                Toggle("", isOn: isPushAuthorizationEnabled)
+                    .labelsHidden()
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 20)
+                    .tint(YDSColor.buttonPoint)
+                    .frame(height: 48)
+                    // TODO: onChange 액션 추가
+            }
+        }
+    }
+}

--- a/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
@@ -16,9 +16,9 @@ enum RightItem {
 
 struct ListRowView: View {
     let title: String
-    let items: [ItemModel]
+    let items: [RowView]
         
-    init(title: String, items: [ItemModel]) {
+    init(title: String, items: [RowView]) {
         self.title = title
         self.items = items
     }
@@ -40,7 +40,7 @@ struct ListRowView: View {
     }
 }
 
-struct ItemModel: View {
+struct RowView: View {
     let text: String
     let rightItem: RightItem
     let action: () -> Void

--- a/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
@@ -63,8 +63,8 @@ struct ItemModel: View {
                             switch rightItem {
                             case .none:
                                 action()
-                            case .toggle(let isPushAuthorizationEnabled):
-                                return
+                            case .toggle(_):
+                                break
                             }
                         }
                 )
@@ -79,13 +79,9 @@ struct ItemModel: View {
                     .padding(.vertical, 20)
                     .tint(YDSColor.buttonPoint)
                     .frame(height: 48)
-                    // TODO: onChange 액션 추가
-                    .onChange(of: isPushAuthorizationEnabled) {
+                    .onChange(of: isPushAuthorizationEnabled.wrappedValue) { newValue in
                         action()
                     }
-//                    .onReceive(isPushAuthorizationEnabled.projectedValue) { newValue in
-//                                action()
-//                            }
             }
         }
     }

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -47,53 +47,42 @@ struct SettingView: View {
                 ListRowView(
                     title: "계정관리",
                     items: [
-                        itemAction(
-                            text: "로그아웃",
-                            action: {
-                                listItemTapped(.logout)
-                            }
-                        )
+                        ItemModel(text: "로그아웃",
+                                  rightItem: .none,
+                                  action: {
+                                      listItemTapped(.logout)
+                                  }
+                                 )
                     ]
                 )
-                VStack(alignment: .leading, spacing: 0) {
-                    Text("알림")
-                        .font(YDSFont.subtitle3)
-                        .foregroundColor(YDSColor.textSecondary)
-                        .padding(20)
-                        .frame(height: 48)
-                    HStack {
-                        Text("성적 알림 받기")
-                            .font(YDSFont.button3)
-                            .foregroundColor(YDSColor.textSecondary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        
-                        Toggle("", isOn: $isPushAuthorizationEnabled)
-                            .labelsHidden()
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 20)
-                            .tint(YDSColor.buttonPoint)
-                            .onChange(of: isPushAuthorizationEnabled) { newValue in
-                                listItemTapped(.toggleAuthorization(newValue))
-                            }
-                    }
-                    .padding(20)
-                    .frame(height: 48)
-                }
+                
+                ListRowView(title: "알림",
+                            items: [
+                                ItemModel(text: "성적 알림 받기",
+                                          rightItem: .toggle(
+                                            isPushAuthorizationEnabled: $isPushAuthorizationEnabled
+                                          ),
+                                          action: {
+                                              // TODO: onChange 호출시 액션 전달
+                                          }
+                                         )
+                            ])
+                
                 ListRowView(
                     title: "약관",
                     items: [
-                        itemAction(
-                            text: "이용약관",
-                            action: {
-                                listItemTapped(.termsOfService)
-                            }
-                        ),
-                        itemAction(
-                            text: "개인정보 처리 방침",
-                            action: {
-                                listItemTapped(.privacyPolicy)
-                            }
-                        )
+                        ItemModel(text: "이용약관",
+                                  rightItem: .none,
+                                  action: {
+                                      listItemTapped(.termsOfService)
+                                  }
+                                 ),
+                        ItemModel(text: "개인정보 처리 방침",
+                                  rightItem: .none,
+                                  action: {
+                                      listItemTapped(.privacyPolicy)
+                                  }
+                                 )
                     ]
                 )
                 Spacer()
@@ -109,72 +98,11 @@ private extension SettingView {
     }
 }
 
-// MARK: - List
 enum listItem {
     case logout
     case toggleAuthorization(Bool)
     case termsOfService
     case privacyPolicy
-}
-
-struct itemAction {
-    let text: String
-    let action: () -> Void
-}
-
-struct ListRowView: View {
-    let title: String
-    let items: [itemAction]
-    
-    @State private var pressedStates: [Bool]
-    
-    init(title: String, items: [itemAction]) {
-        self.title = title
-        self.items = items
-        self._pressedStates = State(initialValue: Array(repeating: false, count: items.count))
-    }
-    
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(title)
-                .font(YDSFont.subtitle3)
-                .foregroundColor(YDSColor.textSecondary)
-                .padding(20)
-                .frame(height: 48)
-            
-            ForEach(items.indices, id: \.self) { index in
-                ItemModel(
-                    text: items[index].text,
-                    action: items[index].action,
-                    isPressed: $pressedStates[index]
-                )
-            }
-        }
-    }
-}
-
-struct ItemModel: View {
-    let text: String
-    let action: () -> Void
-    @Binding var isPressed: Bool
-    
-    var body: some View {
-        Text(text)
-            .font(YDSFont.button3)
-            .foregroundColor(YDSColor.textSecondary)
-            .padding(20)
-            .frame(height: 48)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isPressed ? Color(red: 0.95, green: 0.96, blue: 0.97) : Color.clear)
-            .gesture(
-                DragGesture(minimumDistance: 0)
-                    .onChanged { _ in isPressed = true }
-                    .onEnded { _ in
-                        isPressed = false
-                        action()
-                    }
-            )
-    }
 }
 
 #Preview {

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -47,7 +47,7 @@ struct SettingView: View {
                 ListRowView(
                     title: "계정관리",
                     items: [
-                        ItemModel(text: "로그아웃",
+                        RowView(text: "로그아웃",
                                   rightItem: .none,
                                   action: {
                                       listItemTapped(.logout)
@@ -59,7 +59,7 @@ struct SettingView: View {
                 ListRowView(
                     title: "알림",
                     items: [
-                        ItemModel(text: "성적 알림 받기",
+                        RowView(text: "성적 알림 받기",
                                   rightItem: .toggle(
                                     isPushAuthorizationEnabled: $isPushAuthorizationEnabled
                                   ),
@@ -72,14 +72,14 @@ struct SettingView: View {
                 ListRowView(
                     title: "약관",
                     items: [
-                        ItemModel(
+                        RowView(
                             text: "이용약관",
                             rightItem: .none,
                             action: {
                                 listItemTapped(.termsOfService)
                             }
                         ),
-                        ItemModel(
+                        RowView(
                             text: "개인정보 처리 방침",
                             rightItem: .none,
                             action: {
@@ -92,7 +92,7 @@ struct SettingView: View {
                 ListRowView(
                     title: "버전정보",
                     items: [
-                        ItemModel(
+                        RowView(
                             text: currentAppVersion(),
                             rightItem: .none,
                             action: {}

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -15,37 +15,25 @@ struct SettingView: View {
     
     var body: some View {
         WithPerceptionTracking {
-//            if let store = store.scope(state: \.appState, action: \.appState) {
-//                AppView(store: store)
-//            } else {
-//                NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
-                    VStack(spacing: 4) {
-                        title
-                        SettingList(isPushAuthorizationEnabled: $store.permission) { tappedItem in
-                            switch tappedItem {
-                            case .logout:
-                                store.send(.logoutButtonTapped)
-                            case .toggleAuthorization(let granted):
-                                store.send(.togglePushAuthorization(granted))
-                            case .termsOfService:
-                                store.send(.termsOfServiceButtonTapped)
-                            case .privacyPolicy:
-                                store.send(.privacyPolicyButtonTapped)
-                            }
-                        }
+            VStack(spacing: 4) {
+                title
+                SettingList(isPushAuthorizationEnabled: $store.permission) { tappedItem in
+                    switch tappedItem {
+                    case .logout:
+                        store.send(.logoutButtonTapped)
+                    case .toggleAuthorization(let granted):
+                        store.send(.togglePushAuthorization(granted))
+                    case .termsOfService:
+                        store.send(.termsOfServiceButtonTapped)
+                    case .privacyPolicy:
+                        store.send(.privacyPolicyButtonTapped)
                     }
-                    .registerYDSToast()
-
-//                } destination: { store in
-//                    switch store.case {
-//                    case .navigateToTermsWebView(let store):
-//                        WebView(store: store)
-//                    }
-//                }
-                .alert(
-                    $store.scope(state: \.alert, action: \.alert)
-                )
-//            }
+                }
+            }
+            .registerYDSToast()
+            .alert(
+                $store.scope(state: \.alert, action: \.alert)
+            )
         }
     }
     

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -65,6 +65,7 @@ struct SettingView: View {
                                   ),
                                   action: {
                                       // TODO: onChange 호출시 액션 전달
+                                      listItemTapped(.toggleAuthorization(isPushAuthorizationEnabled))
                                   }
                                  )
                     ])

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -56,37 +56,50 @@ struct SettingView: View {
                     ]
                 )
                 
-                ListRowView(title: "알림",
-                            items: [
-                                ItemModel(text: "성적 알림 받기",
-                                          rightItem: .toggle(
-                                            isPushAuthorizationEnabled: $isPushAuthorizationEnabled
-                                          ),
-                                          action: {
-                                              // TODO: onChange 호출시 액션 전달
-                                          }
-                                         )
-                            ])
+                ListRowView(
+                    title: "알림",
+                    items: [
+                        ItemModel(text: "성적 알림 받기",
+                                  rightItem: .toggle(
+                                    isPushAuthorizationEnabled: $isPushAuthorizationEnabled
+                                  ),
+                                  action: {
+                                      // TODO: onChange 호출시 액션 전달
+                                  }
+                                 )
+                    ])
                 
                 ListRowView(
                     title: "약관",
                     items: [
-                        ItemModel(text: "이용약관",
-                                  rightItem: .none,
-                                  action: {
-                                      listItemTapped(.termsOfService)
-                                  }
-                                 ),
-                        ItemModel(text: "개인정보 처리 방침",
-                                  rightItem: .none,
-                                  action: {
-                                      listItemTapped(.privacyPolicy)
-                                  }
-                                 )
+                        ItemModel(
+                            text: "이용약관",
+                            rightItem: .none,
+                            action: {
+                                listItemTapped(.termsOfService)
+                            }
+                        ),
+                        ItemModel(
+                            text: "개인정보 처리 방침",
+                            rightItem: .none,
+                            action: {
+                                listItemTapped(.privacyPolicy)
+                            }
+                        )
                     ]
                 )
-                Spacer()
+                
+                ListRowView(
+                    title: "버전정보",
+                    items: [
+                        ItemModel(
+                            text: "v 3.0.2",
+                            rightItem: .none,
+                            action: {}
+                        )
+                    ])
             }
+            Spacer()
         }
     }
 }

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -64,7 +64,6 @@ struct SettingView: View {
                                     isPushAuthorizationEnabled: $isPushAuthorizationEnabled
                                   ),
                                   action: {
-                                      // TODO: onChange 호출시 액션 전달
                                       listItemTapped(.toggleAuthorization(isPushAuthorizationEnabled))
                                   }
                                  )

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -16,7 +16,10 @@ struct SettingView: View {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 4) {
-                SettingList(isPushAuthorizationEnabled: $store.permission) { tappedItem in
+                SettingList(
+                    isPushAuthorizationEnabled: $store.permission,
+                    appVersion: store.appVersion
+                ) { tappedItem in
                     switch tappedItem {
                     case .logout:
                         store.send(.logoutButtonTapped)
@@ -35,11 +38,15 @@ struct SettingView: View {
             )
         }
         .navigationTitle("설정")
+        .onAppear {
+            store.send(.onAppear)
+        }
     }
     
     struct SettingList: View {
         @Binding var isPushAuthorizationEnabled: Bool
         
+        let appVersion: String
         let listItemTapped: (listItem) -> Void
         
         var body: some View {
@@ -93,7 +100,7 @@ struct SettingView: View {
                     title: "버전정보",
                     items: [
                         RowView(
-                            text: currentAppVersion(),
+                            text: "v \(appVersion)",
                             rightItem: .none,
                             action: {}
                         )
@@ -101,17 +108,6 @@ struct SettingView: View {
             }
             Spacer()
         }
-    }
-}
-
-private extension SettingView.SettingList {
-    func currentAppVersion() -> String {
-        if let info: [String: Any] = Bundle.main.infoDictionary,
-           let currentVersion: String
-            = info["CFBundleShortVersionString"] as? String {
-            return currentVersion
-        }
-        return "-"
     }
 }
 

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -16,7 +16,6 @@ struct SettingView: View {
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 4) {
-                title
                 SettingList(isPushAuthorizationEnabled: $store.permission) { tappedItem in
                     switch tappedItem {
                     case .logout:
@@ -35,6 +34,7 @@ struct SettingView: View {
                 $store.scope(state: \.alert, action: \.alert)
             )
         }
+        .navigationTitle("설정")
     }
     
     struct SettingList: View {
@@ -104,21 +104,14 @@ struct SettingView: View {
     }
 }
 
-private extension SettingView {
-    var title: some View {
-        Text("설정")
-            .font(YDSFont.subtitle2)
-    }
-}
-
 private extension SettingView.SettingList {
     func currentAppVersion() -> String {
-      if let info: [String: Any] = Bundle.main.infoDictionary,
-          let currentVersion: String
+        if let info: [String: Any] = Bundle.main.infoDictionary,
+           let currentVersion: String
             = info["CFBundleShortVersionString"] as? String {
             return currentVersion
-      }
-      return "-"
+        }
+        return "-"
     }
 }
 

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -93,7 +93,7 @@ struct SettingView: View {
                     title: "버전정보",
                     items: [
                         ItemModel(
-                            text: "v 3.0.2",
+                            text: currentAppVersion(),
                             rightItem: .none,
                             action: {}
                         )
@@ -108,6 +108,17 @@ private extension SettingView {
     var title: some View {
         Text("설정")
             .font(YDSFont.subtitle2)
+    }
+}
+
+private extension SettingView.SettingList {
+    func currentAppVersion() -> String {
+      if let info: [String: Any] = Bundle.main.infoDictionary,
+          let currentVersion: String
+            = info["CFBundleShortVersionString"] as? String {
+            return currentVersion
+      }
+      return "-"
     }
 }
 


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- Setting ListView 분리
- 버튼 네이밍 컨벤션 반영
- 버전 정보 추가
- 액션 완료시, YDS 토스트 추가
- 버튼 클릭 영역 전체 cell 부분으로 수정


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #84 
- 피그마 : 
- 관련 문서 :
- close: #84 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
SettingView 내에 있던 List를 분리하는 과정에서 아래와 같은 이슈가 있습니다.
1. `.toggle` 의 경우 `Binding<Bool>` 타입의 연관값을 받습니다.
```
enum RightItem {
    case none
    case toggle(isOn: Binding<Bool>)
}
```
2. onChange의 of 인자는 Equatable한 값을 전달해야하기 때문에 `isOn.wrappedValue`로 전달하였습니다.
```
            switch rightItem {
            ...
            case .toggle(let isOn):
                Toggle("", isOn: isOn)
                  ...
                    // TODO: onChange 액션 추가
                    .onChange(of: isOn.wrappedValue) {
                        action()
                    }
            }
```
- 위와 같이 작성하면 아래와 같은 버전 이슈가 발생합니다. `.onReceive`를 사용하는 방법으로 해결해야할까요? 
<img width="406" alt="스크린샷 2025-02-10 오후 5 04 54" src="https://github.com/user-attachments/assets/dd47e1b3-1209-4c19-8bc0-a4342bbc1d43" />

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

<img width="364" alt="스크린샷 2025-02-11 오후 3 10 06" src="https://github.com/user-attachments/assets/ebabc054-bb81-4778-9920-f312c740429b" />

