### PR TITLE
[#63] Firebase RemoteConfig 연동

### DIFF
--- a/Soomsil-USaint.xcodeproj/project.pbxproj
+++ b/Soomsil-USaint.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		02C46D912D0F45B200A3E717 /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = 02C46D902D0F45B200A3E717 /* RxRelay */; };
 		7B75DB312D3A374B00FF2FBE /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 7B75DB302D3A374B00FF2FBE /* ComposableArchitecture */; };
 		7BA4D7D32D17FAE700CF6689 /* Rusaint in Frameworks */ = {isa = PBXBuildFile; productRef = 7BA4D7D22D17FAE700CF6689 /* Rusaint */; };
+		B96F06662D63882B0047D33D /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = B96F06652D63882B0047D33D /* FirebaseCore */; };
+		B96F06682D63882B0047D33D /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = B96F06672D63882B0047D33D /* FirebaseRemoteConfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -54,7 +56,9 @@
 				02C46CF52D0F2E9300A3E717 /* YDS-SwiftUI in Frameworks */,
 				02C46D8F2D0F45B200A3E717 /* RxCocoa in Frameworks */,
 				7B75DB312D3A374B00FF2FBE /* ComposableArchitecture in Frameworks */,
+				B96F06662D63882B0047D33D /* FirebaseCore in Frameworks */,
 				02C46D8D2D0F45B200A3E717 /* RxBlocking in Frameworks */,
+				B96F06682D63882B0047D33D /* FirebaseRemoteConfig in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -105,6 +109,8 @@
 				02C46D902D0F45B200A3E717 /* RxRelay */,
 				7BA4D7D22D17FAE700CF6689 /* Rusaint */,
 				7B75DB302D3A374B00FF2FBE /* ComposableArchitecture */,
+				B96F06652D63882B0047D33D /* FirebaseCore */,
+				B96F06672D63882B0047D33D /* FirebaseRemoteConfig */,
 			);
 			productName = "Rusaint-iOS";
 			productReference = 02C46CBE2D0F138700A3E717 /* Soomsil-USaint.app */;
@@ -140,6 +146,7 @@
 				02C46D8B2D0F45B200A3E717 /* XCRemoteSwiftPackageReference "RxSwift" */,
 				7BA4D7D12D17FAE700CF6689 /* XCRemoteSwiftPackageReference "rusaint-ios" */,
 				7B75DB2F2D3A374B00FF2FBE /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
+				B96F06642D63882B0047D33D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 02C46CBF2D0F138700A3E717 /* Products */;
@@ -435,6 +442,14 @@
 				minimumVersion = 0.8.2;
 			};
 		};
+		B96F06642D63882B0047D33D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 11.8.1;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -477,6 +492,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 7BA4D7D12D17FAE700CF6689 /* XCRemoteSwiftPackageReference "rusaint-ios" */;
 			productName = Rusaint;
+		};
+		B96F06652D63882B0047D33D /* FirebaseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B96F06642D63882B0047D33D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
+		};
+		B96F06672D63882B0047D33D /* FirebaseRemoteConfig */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B96F06642D63882B0047D33D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseRemoteConfig;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Soomsil-USaint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Soomsil-USaint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "3fad13c882a08211597ca586b50a9eb013bc8775f1ce7024a83dc890cfa545e1",
+  "originHash" : "2cd7be355296c8d8b7324fc9365a54f1715e432052a886a0c719e2356aa2c54f",
   "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "194a6706acbd25e4ef639bcaddea16e8758a3e27",
+        "version" : "1.2024011602.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
@@ -11,12 +29,93 @@
       }
     },
     {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "6318278e8e64d21f0fdcc69004395e4d34048aaf",
+        "version" : "11.8.1"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "be0881ff728eca210ccb628092af400c086abda3",
+        "version" : "11.7.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "53156c7ec267db846e6b64c9f4c4e31ba4cf75eb",
+        "version" : "8.0.2"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "f56d8fc3162de9a498377c7b6cea43431f4f5083",
+        "version" : "1.65.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "3cdb78efb79b4a5383c3911488d8025bfc545b5e",
+        "version" : "4.3.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
       "identity" : "keychainaccess",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kishikawakatsumi/KeychainAccess.git",
       "state" : {
         "branch" : "master",
         "revision" : "e0c7eebc5a4465a3c4680764f26b7a61f567cdaf"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
       }
     },
     {
@@ -35,6 +134,15 @@
       "state" : {
         "revision" : "42036be5d011c83145e9f8e2705c7d3756e46607",
         "version" : "3.7.2"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {
@@ -152,6 +260,15 @@
       "state" : {
         "revision" : "8d52279b9809ef27eabe7d5420f03734528f19da",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
+        "version" : "1.28.2"
       }
     },
     {

--- a/Soomsil-USaint/Application/AppReducer.swift
+++ b/Soomsil-USaint/Application/AppReducer.swift
@@ -51,8 +51,7 @@ struct AppReducer {
                 return .send(.initialize)
             case .checkMinimumVersionResponse(.failure(let error)):
                 debugPrint("Error at AppReducer - \(error)")
-                // TODO: 에러 처리
-                return .none
+                return .send(.initialize)
             case .initialize:
                 return .run { send in
                     await send(.initResponse(Result {

--- a/Soomsil-USaint/Application/AppView.swift
+++ b/Soomsil-USaint/Application/AppView.swift
@@ -17,7 +17,7 @@ struct AppView: View {
         case .initial:
             SplashView()
                 .onAppear {
-                    store.send(.initialize)
+                    store.send(.checkMinimumVersion)
                 }
         case .loggedOut:
             if let store = store.scope(state: \.loggedOut, action: \.login) {

--- a/Soomsil-USaint/Application/AppView.swift
+++ b/Soomsil-USaint/Application/AppView.swift
@@ -15,10 +15,9 @@ struct AppView: View {
     var body: some View {
         switch store.state {
         case .initial:
-            SplashView()
-                .onAppear {
-                    store.send(.checkMinimumVersion)
-                }
+            if let store = store.scope(state: \.initial, action: \.splash) {
+                SplashView(store: store)
+            }
         case .loggedOut:
             if let store = store.scope(state: \.loggedOut, action: \.login) {
                 LoginView(store: store)

--- a/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
@@ -76,7 +76,7 @@ struct SplashReducer {
                         }
                     },
                     message: {
-                        TextState(error.localizedDescription)
+                        TextState("버전 정보를 불러오는 데 실패했습니다.\n네트워크 상태를 확인한 후 다시 시도해주세요.")
                     }
                 )
                 return .none

--- a/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
@@ -1,0 +1,38 @@
+//
+//  SplashReducer.swift
+//  Soomsil-USaint
+//
+//  Created by 정지혁 on 2/27/25.
+//
+
+import Foundation
+
+import ComposableArchitecture
+
+@Reducer
+struct SplashReducer {
+    @ObservableState
+    struct State {
+        @Presents var alert: AlertState<Action.Alert>?
+    }
+    
+    enum Action {
+        case alert(PresentationAction<Alert>)
+        case checkMinimumVersion
+        case checkMinimumVersionResponse(Result<String, Error>)
+        case initialize
+        case initResponse(Result<StudentInfo, Error>)
+        
+        enum Alert: Equatable {
+            case moveAppStoreTapped
+        }
+    }
+    
+    @Dependency(\.remoteConfigClient) var remoteConfigClient
+    
+    var body: some Reducer<State, Action> {
+        Reduce { state, action in
+            return .none
+        }
+    }
+}

--- a/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
@@ -21,18 +21,86 @@ struct SplashReducer {
         case checkMinimumVersion
         case checkMinimumVersionResponse(Result<String, Error>)
         case initialize
-        case initResponse(Result<StudentInfo, Error>)
+        case initResponse(Result<(StudentInfo, TotalReportCard), Error>)
         
         enum Alert: Equatable {
+            case confirmTapped
             case moveAppStoreTapped
         }
     }
     
     @Dependency(\.remoteConfigClient) var remoteConfigClient
+    @Dependency(\.gradeClient) var gradeClient
+    @Dependency(\.studentClient) var studentClient
+    @Dependency(\.openURL) var openURL
     
     var body: some Reducer<State, Action> {
         Reduce { state, action in
-            return .none
+            switch action {
+            case .alert(.presented(.confirmTapped)):
+                return .none
+            case .alert(.presented(.moveAppStoreTapped)):
+                return .run { _ in
+                    await openURL(URL(string: "itms-apps://itunes.apple.com/app/id1601044486")!)
+                }
+            case .checkMinimumVersion:
+                return .run { send in
+                    await send(.checkMinimumVersionResponse(Result {
+                        return try await remoteConfigClient.getMinimumVersion()
+                    }))
+                }
+            case .checkMinimumVersionResponse(.success(let minimumVersion)):
+                if checkMinimumVersion(minimum: minimumVersion) {
+                    return .send(.initialize)
+                } else {
+                    state.alert = AlertState(
+                        title: { TextState("앱 업데이트가 있어요") },
+                        actions: {
+                            ButtonState(action: .send(.moveAppStoreTapped)) {
+                                TextState("스토어로 이동하기")
+                            }
+                        },
+                        message: {
+                            TextState("원활한 서비스 이용을 위해\n업데이트가 필요해요")
+                        }
+                    )
+                    return .none
+                }
+            case .checkMinimumVersionResponse(.failure(let error)):
+                debugPrint(error.localizedDescription)
+                state.alert = AlertState(
+                    title: { TextState("네트워크 에러") },
+                    actions: {
+                        ButtonState(action: .send(.confirmTapped)) {
+                            TextState("확인")
+                        }
+                    },
+                    message: {
+                        TextState(error.localizedDescription)
+                    }
+                )
+                return .none
+            case .initialize:
+                return .run { send in
+                    await send(.initResponse(Result {
+                        let info = try await studentClient.getStudentInfo()
+                        let card = try await gradeClient.getTotalReportCard()
+                        return (info, card)
+                    }))
+                }
+            default:
+                return .none
+            }
         }
+        .ifLet(\.$alert, action: \.alert)
+    }
+    
+    func checkMinimumVersion(minimum minimumVersion: String) -> Bool {
+        let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+        
+        let current = currentVersion.split(separator: ".").map { Int($0) ?? 0 }
+        let minimum = minimumVersion.split(separator: ".").map { Int($0) ?? 0 }
+        
+        return (current[0], current[1], current[2]) >= (minimum[0], minimum[1], minimum[2])
     }
 }

--- a/Soomsil-USaint/Application/Feature/Splash/View/SplashView.swift
+++ b/Soomsil-USaint/Application/Feature/Splash/View/SplashView.swift
@@ -7,10 +7,26 @@
 
 import SwiftUI
 
+import ComposableArchitecture
+
 struct SplashView: View {
+    @Perception.Bindable var store: StoreOf<SplashReducer>
+    
     var body: some View {
-        Image("splash")
-            .resizable()
-            .aspectRatio(contentMode: .fill)
+        WithPerceptionTracking {
+            Image("splash")
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .alert($store.scope(state: \.alert, action: \.alert))
+        }
+        .onAppear {
+            store.send(.checkMinimumVersion)
+        }
     }
+}
+
+#Preview {
+    SplashView(store: Store(initialState: SplashReducer.State()) {
+        SplashReducer()
+    })
 }

--- a/Soomsil-USaint/Application/Rusaint_iOSApp.swift
+++ b/Soomsil-USaint/Application/Rusaint_iOSApp.swift
@@ -9,10 +9,20 @@ import SwiftUI
 import BackgroundTasks
 
 import ComposableArchitecture
+import FirebaseCore
 import Rusaint
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        FirebaseApp.configure()
+        return true
+    }
+}
 
 @main
 struct Rusaint_iOSApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    
     @Environment(\.scenePhase) var scenePhase
     
     let store = Store(initialState: AppReducer.State()) { AppReducer() }

--- a/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
+++ b/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
@@ -38,7 +38,7 @@ extension RemoteConfigClient: DependencyKey {
     
     static let previewValue: RemoteConfigClient = Self(
         getMinimumVersion: {
-            return "1.0.0"
+            return "3.0.2"
         }
     )
     

--- a/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
+++ b/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
@@ -1,0 +1,46 @@
+//
+//  RemoteConfigClient.swift
+//  Soomsil-USaint
+//
+//  Created by 정지혁 on 2/18/25.
+//
+
+import Foundation
+
+import ComposableArchitecture
+import FirebaseRemoteConfig
+
+@DependencyClient
+struct RemoteConfigClient {
+    private static let minimumVersionkey: String = "min_version_ios"
+    
+    var getMinimumVersion: @Sendable () async throws -> String
+}
+
+extension DependencyValues {
+    var remoteConfigClient: RemoteConfigClient {
+        get { self[RemoteConfigClient.self] }
+        set { self[RemoteConfigClient.self] = newValue }
+    }
+}
+
+extension RemoteConfigClient: DependencyKey {
+    static let liveValue: RemoteConfigClient = Self(
+        getMinimumVersion: {
+            let remoteConfig = RemoteConfig.remoteConfig()
+            try await remoteConfig.fetchAndActivate()
+            
+            let minimumVersion = remoteConfig[minimumVersionkey].stringValue
+            debugPrint(minimumVersion)
+            return minimumVersion
+        }
+    )
+    
+    static let previewValue: RemoteConfigClient = Self(
+        getMinimumVersion: {
+            return "1.0.0"
+        }
+    )
+    
+    static let testValue: RemoteConfigClient = previewValue
+}

--- a/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
+++ b/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
@@ -31,14 +31,13 @@ extension RemoteConfigClient: DependencyKey {
             try await remoteConfig.fetchAndActivate()
             
             let minimumVersion = remoteConfig[minimumVersionkey].stringValue
-            debugPrint(minimumVersion)
             return minimumVersion
         }
     )
     
     static let previewValue: RemoteConfigClient = Self(
         getMinimumVersion: {
-            return "3.0.2"
+            return "3.0.3"
         }
     )
     

--- a/Soomsil-USaint/GoogleService-Info.plist
+++ b/Soomsil-USaint/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyDpHLpOch4gBX2fqS313wTrQH2IUzHmlg0</string>
+	<key>GCM_SENDER_ID</key>
+	<string>52701294141</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>com.yourssu.SaintKit</string>
+	<key>PROJECT_ID</key>
+	<string>soomsil-usaint</string>
+	<key>STORAGE_BUCKET</key>
+	<string>soomsil-usaint.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:52701294141:ios:e6a52f5369e1afd0814454</string>
+</dict>
+</plist>


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
Firebase 프로젝트 생성 및 Remote Config(만) 연결 PR입니다.
따로 GA나 기능을 추가하진 않고, Firebase Core와 Firebase RemoteConfig만 추가했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #63
- 피그마 : 
- 관련 문서 :
- close: #63

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
~~1. RemoteConfig를 사용할 때, 최소버전 비교 및 오류 처리를 어떻게 하면 좋을까요?
최소버전 여부를 판단하고, 최소버전보다 이전 버전 사용자에게 어디서 어떻게 Alert이나 Sheet를 띄우면 좋을까요..?
그리고 RemoteConfig 관련 설정은 건드리진 않았고, 앱에서 기본값나 업데이트 리스너도 아직 붙어있진 않습니다. 해당 기능에 대해 구체적인 요구사항이 필요해요.~~

~~2. 유어슈 계정으로 파이어베이스 프로젝트 초대 보냈습니다. 확인 부탁드립니다!~~

3. 지난 회의 때 논의된대로, SplashReducer 구현 및 AppReducer를 수정했습니다. 전반적인 로직은 SplashReducer로 이관하였고, 앱 업데이트 및 네트워크 오류 Alert을 구현했습니다.


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
https://firebase.google.com/docs/remote-config/get-started?hl=ko&_gl=1*1otwmqh*_up*MQ..*_ga*MTI4NzQzMzI3OS4xNzM5ODA4OTk3*_ga_CW55HF8NVT*MTczOTgwODk5Ny4xLjAuMTczOTgwODk5Ny4wLjAuMA..&platform=ios


## 🔥 Test
<!-- Test -->
<img width="300" src="https://github.com/user-attachments/assets/10ccffc5-8ab3-4324-a0c4-bc746ed85234" />
