### PR TITLE
[#117] 홈화면 채플 정보 추가

### DIFF
--- a/Soomsil-USaint/Application/AppReducer.swift
+++ b/Soomsil-USaint/Application/AppReducer.swift
@@ -42,14 +42,14 @@ struct AppReducer {
                 return .run { send in
                     try await scheduleChangedGardeLecturePush()
                 }
-            case .splash(.initResponse(.success(let (studentInfo, totalReportCard)))):
-                state = .loggedIn(HomeReducer.State(studentInfo: studentInfo, totalReportCard: totalReportCard))
+            case .splash(.initResponse(.success(let (studentInfo, totalReportCard, chapelCard)))):
+                state = .loggedIn(HomeReducer.State(studentInfo: studentInfo, totalReportCard: totalReportCard, chapelCard: chapelCard))
                 return .none
             case .splash(.initResponse(.failure)):
                 state = .loggedOut(LoginReducer.State())
                 return .none
-            case .login(.loginResponse(.success(let (info, report)))):
-                state = .loggedIn(HomeReducer.State(studentInfo: info, totalReportCard: report))
+            case .login(.loginResponse(.success(let (info, report, chapel)))):
+                state = .loggedIn(HomeReducer.State(studentInfo: info, totalReportCard: report, chapelCard: chapel))
                 return .none
             case .home(.path(.element(id: _, action: .setting(.logoutCompleted)))):
                 state = .loggedOut(LoginReducer.State())

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -28,6 +28,7 @@ struct HomeReducer {
         
         var studentInfo: StudentInfo
         var totalReportCard: TotalReportCard
+        var chapelCard: ChapelCard
     }
     
     enum Action: BindableAction {

--- a/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
@@ -7,58 +7,34 @@
 
 import SwiftUI
 
-struct Chapel: View {
-    var seatPos: String = "1층 A-1-2"
-    var attendanceNum: Int = 8
+let mainPurple: Color = Color(hex: "#816DEC")
+
+struct ChapelInfo: View {
+    // 받아올 정보
+    var attendanceCount: Int = 4
+    var seatPosition: String = "1층 A-1-2"
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("채플")
                 .font(.system(size: 18, weight: .bold))
-                .lineSpacing(5.4) // 130% line height 계산: 18 * 0.3 = 5.4
-                .kerning(0) // Letter spacing 0%
+                .lineSpacing(5.4)
+                .kerning(0)
                 .foregroundStyle(Color(hex: "#101112"))
                 .frame(width: 32, height: 23)
             ZStack {
                 Rectangle()
-                    .frame(width: 350, height: 110)
+                    .frame(width: 350, height: 130)
                     .cornerRadius(16)
                     .foregroundStyle(.white)
-                    .shadow(color: Color(hex: "#69603B").opacity(0.07), radius: 7)
+                    .shadow(color: Color(hex: "#FFF").opacity(0.07), radius: 7)
+                
                 VStack(spacing: 0) {
-                    HStack(spacing: 0) {
-                        Text("내 좌석")
-                            .font(.system(size: 15))
-                            .padding(.leading, 28)
-                        Spacer()
-                        Text(seatPos)
-                            .font(.system(size: 16))
-                            .fontWeight(.bold)
-                            .foregroundStyle(Color(hex: "#816DEC"))
-                            .padding(.trailing, 28)
-                    }
-                    .frame(width: 350, height: 37)
-                    
-                    HStack(spacing: 0) {
-                        Text("출결 정보")
-                            .font(.system(size: 15))
-                            .padding(.leading, 28)
-                        Spacer()
-                        Text("\(attendanceNum)")
-                            .font(.system(size: 16))
-                            .fontWeight(.bold)
-                            .foregroundStyle(Color(hex: "#816DEC"))
-                        Text(" / 12")
-                            .font(.system(size: 10))
-                            .padding(.trailing, 28)
-                            .foregroundStyle(Color(hex: "#8E9398"))
-                            .offset(y: 2)
-                    }
-                    .frame(width: 350, height: 37)
+                    AttendanceView(attendanceCount)
+                    SeatPositionView(seatPosition)
+                    Divider()
+                        .frame(width: 330)
                 }
-                Rectangle() // Divider
-                    .foregroundStyle(Color(hex: "#101112").opacity(0.1))
-                    .frame(width: 330, height: 0.34)
             }
             .padding(.top, 14.5)
         }
@@ -67,6 +43,109 @@ struct Chapel: View {
     }
 }
 
+private struct AttendanceView: View {
+    let maxAttendanceCount: Int = 12
+    var attendanceCount: Int
+    var remainToPassCount: Int
+    
+    init(_ attendanceCount: Int) {
+        self.attendanceCount = attendanceCount
+        self.remainToPassCount = (maxAttendanceCount / 3) * 2 - attendanceCount
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                Text("Pass까지 ")
+                + Text("\(remainToPassCount)회 ")
+                    .foregroundStyle(mainPurple)
+                + Text("남았어요")
+                    .font(.system(size: 15))
+                Spacer()
+                Text("\(attendanceCount)")
+                    .font(.system(size: 16))
+                    .fontWeight(.bold)
+                    .foregroundStyle(mainPurple)
+                + Text(" / \(maxAttendanceCount)")
+                    .font(.system(size: 10))
+                    .foregroundStyle(Color(hex: "#8E9398"))
+            }
+            .frame(width: 304, height: 23)
+            .padding(.bottom, 5)
+            
+            ProgressView (value: Double(attendanceCount), total: Double(maxAttendanceCount))
+                .frame(width: 304, height: 6.6)
+                .progressViewStyle(
+                    CustomLinearProgressViewStyle(
+                        progressColor: mainPurple,
+                        trackColor: Color(hex: "#E5E1FA")
+                    )
+                )
+        }
+    }
+}
+
+private struct CustomLinearProgressViewStyle: ProgressViewStyle {
+    var progressColor: Color
+    var trackColor: Color
+    
+    func makeBody(configuration: Configuration) -> some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                // 트랙 (진행 안된 부분)
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(trackColor)
+                    .frame(height: 6.6)
+                // 진행된 부분
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(progressColor)
+                    .frame(width: geometry.size.width * CGFloat(configuration.fractionCompleted ?? 0), height: 6.6)
+                // Pass 지점
+                Rectangle()
+                    .fill(mainPurple)
+                    .frame(width: 2, height: 9)
+                    .cornerRadius(1)
+                    .position(
+                        x: geometry.size.width * (2.0 / 3.0),
+                        y: geometry.size.height / 2
+                    )
+            }
+        }
+        .frame(height: 6.6)
+    }
+}
+
+private struct SeatPositionView: View {
+    var seatPosition: String
+    
+    init(_ seatPosition: String) {
+        self.seatPosition = seatPosition
+    }
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            Text("좌석 정보")
+                .font(.system(size: 15))
+                .padding(.leading, 28)
+            Spacer()
+            Text(seatPosition)
+                .font(.system(size: 16))
+                .fontWeight(.bold)
+                .foregroundStyle(mainPurple)
+                .padding(.trailing, 28)
+        }
+        .frame(width: 350, height: 37)
+        .padding(.top, 18)
+    }
+}
+
+
+#Preview {
+    ChapelInfo()
+}
+
+
+// FIXME: Hex 색상코드를 사용하기 위해 임시로 추가
 extension Color {
     init(hex: String) {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
@@ -91,14 +170,5 @@ extension Color {
             blue:  Double(b) / 255,
             opacity: Double(a) / 255
         )
-    }
-}
-
-
-#Preview {
-    ZStack {
-        Color.yellow
-            .edgesIgnoringSafeArea(.all)
-        Chapel()
     }
 }

--- a/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
@@ -11,8 +11,9 @@ let mainPurple: Color = Color(hex: "#816DEC")
 
 struct ChapelInfo: View {
     // 받아올 정보
-    var attendanceCount: Int = 4
-    var seatPosition: String = "1층 A-1-2"
+    var chapelCard: ChapelCard
+    var attendanceCount: Int { chapelCard.attendance }
+    var seatPosition: String { chapelCard.seatPosition }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -136,7 +137,7 @@ private struct CustomLinearProgressViewStyle: ProgressViewStyle {
 }
 
 #Preview {
-    ChapelInfo()
+    ChapelInfo(chapelCard: ChapelCard(attendance: 4, seatPosition: "E-10-4"))
 }
 
 

--- a/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
@@ -22,6 +22,7 @@ struct ChapelInfo: View {
                 .kerning(0)
                 .foregroundStyle(Color(hex: "#101112"))
                 .frame(width: 32, height: 23)
+            
             ZStack {
                 Rectangle()
                     .frame(width: 350, height: 130)
@@ -50,7 +51,7 @@ private struct AttendanceView: View {
     
     init(_ attendanceCount: Int) {
         self.attendanceCount = attendanceCount
-        self.remainToPassCount = (maxAttendanceCount / 3) * 2 - attendanceCount
+        self.remainToPassCount = max(0, (maxAttendanceCount / 3) * 2 - attendanceCount)
     }
     
     var body: some View {
@@ -85,6 +86,28 @@ private struct AttendanceView: View {
     }
 }
 
+private struct SeatPositionView: View {
+    var seatPosition: String
+    
+    init(_ seatPosition: String) {
+        self.seatPosition = seatPosition
+    }
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            Text("좌석 정보")
+                .font(.system(size: 15))
+            Spacer()
+            Text(seatPosition)
+                .font(.system(size: 16))
+                .fontWeight(.bold)
+                .foregroundStyle(mainPurple)
+        }
+        .frame(width: 294, height: 39)
+        .padding(.top, 18)
+    }
+}
+
 private struct CustomLinearProgressViewStyle: ProgressViewStyle {
     var progressColor: Color
     var trackColor: Color
@@ -92,15 +115,12 @@ private struct CustomLinearProgressViewStyle: ProgressViewStyle {
     func makeBody(configuration: Configuration) -> some View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
-                // 트랙 (진행 안된 부분)
                 RoundedRectangle(cornerRadius: 10)
                     .fill(trackColor)
                     .frame(height: 6.6)
-                // 진행된 부분
                 RoundedRectangle(cornerRadius: 10)
                     .fill(progressColor)
                     .frame(width: geometry.size.width * CGFloat(configuration.fractionCompleted ?? 0), height: 6.6)
-                // Pass 지점
                 Rectangle()
                     .fill(mainPurple)
                     .frame(width: 2, height: 9)
@@ -114,31 +134,6 @@ private struct CustomLinearProgressViewStyle: ProgressViewStyle {
         .frame(height: 6.6)
     }
 }
-
-private struct SeatPositionView: View {
-    var seatPosition: String
-    
-    init(_ seatPosition: String) {
-        self.seatPosition = seatPosition
-    }
-    
-    var body: some View {
-        HStack(spacing: 0) {
-            Text("좌석 정보")
-                .font(.system(size: 15))
-                .padding(.leading, 28)
-            Spacer()
-            Text(seatPosition)
-                .font(.system(size: 16))
-                .fontWeight(.bold)
-                .foregroundStyle(mainPurple)
-                .padding(.trailing, 28)
-        }
-        .frame(width: 350, height: 37)
-        .padding(.top, 18)
-    }
-}
-
 
 #Preview {
     ChapelInfo()

--- a/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
@@ -7,13 +7,14 @@
 
 import SwiftUI
 
-let mainPurple: Color = Color(hex: "#816DEC")
-
 struct ChapelInfo: View {
-    // 받아올 정보
+    // 받아오는 정보
     var chapelCard: ChapelCard
     var attendanceCount: Int { chapelCard.attendance }
-    var seatPosition: String { chapelCard.seatPosition }
+    var seatPosition: String {
+        chapelCard.seatPosition.components(separatedBy: .whitespaces).joined()
+    }
+    var floorLevel: UInt32 { chapelCard.floorLevel }
     var status: ChapelStatus { chapelCard.status }
     
     var body: some View {
@@ -22,19 +23,20 @@ struct ChapelInfo: View {
                 .font(.system(size: 18, weight: .bold))
                 .lineSpacing(5.4)
                 .kerning(0)
-                .foregroundStyle(Color(hex: "#101112"))
+                .foregroundStyle(.titleText)
                 .frame(width: 32, height: 23)
             
             ZStack {
                 Rectangle()
                     .frame(width: 350, height: 130)
                     .cornerRadius(16)
-                    .foregroundStyle(.white)
-                    .shadow(color: Color(hex: "#FFF").opacity(0.07), radius: 7)
+                    .foregroundStyle(.onSurface)
+                    .shadow(color: .shadow, radius: 7)
                 
-                if status == ChapelStatus.active {
-                    ActiveStatusView(attendanceCount, seatPosition)
-                } else {
+                switch status {
+                case .active:
+                    ActiveStatusView(attendanceCount, seatPosition, floorLevel)
+                case .inactive:
                     InactiveStatusView()
                 }
             }
@@ -48,19 +50,24 @@ struct ChapelInfo: View {
 private struct ActiveStatusView: View {
     let attendanceCount: Int
     let seatPosition: String
+    let floorLevel: UInt32
     
-    init(_ attendanceCount: Int, _ seatPosition: String) {
+    init(_ attendanceCount: Int, _ seatPosition: String, _ floorLevel: UInt32) {
         self.attendanceCount = attendanceCount
         self.seatPosition = seatPosition
+        self.floorLevel = floorLevel
     }
     
     var body: some View {
         VStack(spacing: 0) {
             AttendanceView(attendanceCount)
-            SeatPositionView(seatPosition)
             Divider()
                 .frame(width: 330)
+                .padding(.vertical, 18)
+            SeatPositionView(seatPosition, floorLevel)
+            Spacer()
         }
+        .frame(height: 132.34)
     }
 }
 
@@ -68,7 +75,8 @@ private struct InactiveStatusView: View {
     var body: some View {
         Text("채플 수료 완료!")
             .font(.system(size: 18))
-            .foregroundStyle(mainPurple)
+            .fontWeight(.semibold)
+            .foregroundStyle(.vPrimary)
     }
 }
 
@@ -87,19 +95,26 @@ private struct AttendanceView: View {
             HStack(spacing: 0) {
                 Text("Pass까지 ")
                     .font(.system(size: 15))
+                    .foregroundStyle(.titleText)
                 + Text("\(remainToPassCount)회 ")
-                    .font(.system(size: 15))
-                    .foregroundStyle(mainPurple)
-                + Text("남았어요")
-                    .font(.system(size: 15))
-                Spacer()
-                Text("\(attendanceCount)")
                     .font(.system(size: 16))
                     .fontWeight(.bold)
-                    .foregroundStyle(mainPurple)
-                + Text(" / \(maxAttendanceCount)")
-                    .font(.system(size: 10))
-                    .foregroundStyle(Color(hex: "#8E9398"))
+                    .foregroundStyle(.vPrimary)
+                + Text("남았어요")
+                    .font(.system(size: 15))
+                    .foregroundStyle(.titleText)
+                Spacer()
+                Text("\(attendanceCount)")
+                    .font(.custom("AppleSDGothicNeoB00", size: 16))
+                    .fontWeight(.regular)
+                    .foregroundStyle(.vPrimary)
+                + Text(" ")
+                    .font(.custom("NotoSans", size: 16))
+                    .fontWeight(.semibold)
+                + Text("/ \(maxAttendanceCount)")
+                    .font(.custom("NotoSans", size: 12))
+                    .fontWeight(.regular)
+                    .foregroundStyle(.grayText)
             }
             .frame(width: 304, height: 23)
             .padding(.bottom, 5)
@@ -108,19 +123,22 @@ private struct AttendanceView: View {
                 .frame(width: 304, height: 6.6)
                 .progressViewStyle(
                     CustomLinearProgressViewStyle(
-                        progressColor: mainPurple,
-                        trackColor: Color(hex: "#E5E1FA")
+                        progressColor: .vPrimary,
+                        trackColor: Color(ColorResource.secondary)
                     )
                 )
         }
+        .padding(.top, 18)
     }
 }
 
 private struct SeatPositionView: View {
     var seatPosition: String
+    var floorLevel: UInt32
     
-    init(_ seatPosition: String) {
+    init(_ seatPosition: String, _ floorLevel: UInt32) {
         self.seatPosition = seatPosition
+        self.floorLevel = floorLevel
     }
     
     var body: some View {
@@ -128,13 +146,13 @@ private struct SeatPositionView: View {
             Text("좌석 정보")
                 .font(.system(size: 15))
             Spacer()
-            Text(seatPosition)
+            Text("\(floorLevel)층 " + seatPosition)
                 .font(.system(size: 16))
                 .fontWeight(.bold)
-                .foregroundStyle(mainPurple)
+                .foregroundStyle(.vPrimary)
         }
-        .frame(width: 294, height: 39)
-        .padding(.top, 18)
+        .frame(height: 25)
+        .padding(.horizontal, 28)
     }
 }
 
@@ -152,7 +170,7 @@ private struct CustomLinearProgressViewStyle: ProgressViewStyle {
                     .fill(progressColor)
                     .frame(width: geometry.size.width * CGFloat(configuration.fractionCompleted ?? 0), height: 6.6)
                 Rectangle()
-                    .fill(mainPurple)
+                    .fill(.vPrimary)
                     .frame(width: 2, height: 9)
                     .cornerRadius(1)
                     .position(
@@ -167,40 +185,11 @@ private struct CustomLinearProgressViewStyle: ProgressViewStyle {
 
 #Preview {
     ZStack {
-        Color(.lightGray)
+        Color(.surface)
             .ignoresSafeArea(.all)
         VStack {
-            ChapelInfo(chapelCard: ChapelCard(attendance: 4, seatPosition: "E-10-4"))
+            ChapelInfo(chapelCard: ChapelCard(attendance: 4, seatPosition: "E-10-4", floorLevel: 1))
             ChapelInfo(chapelCard: ChapelCard.inactive())
         }
-    }
-}
-
-
-// FIXME: Hex 색상코드를 사용하기 위해 임시로 추가
-extension Color {
-    init(hex: String) {
-        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-        var int: UInt64 = 0
-        Scanner(string: hex).scanHexInt64(&int)
-        let a, r, g, b: UInt64
-        switch hex.count {
-        case 3: // RGB (12-bit)
-            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
-        case 6: // RGB (24-bit)
-            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
-        case 8: // ARGB (32-bit)
-            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
-        default:
-            (a, r, g, b) = (1, 1, 1, 0)
-        }
-        
-        self.init(
-            .sRGB,
-            red: Double(r) / 255,
-            green: Double(g) / 255,
-            blue:  Double(b) / 255,
-            opacity: Double(a) / 255
-        )
     }
 }

--- a/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
@@ -14,6 +14,7 @@ struct ChapelInfo: View {
     var chapelCard: ChapelCard
     var attendanceCount: Int { chapelCard.attendance }
     var seatPosition: String { chapelCard.seatPosition }
+    var status: ChapelStatus { chapelCard.status }
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -31,17 +32,43 @@ struct ChapelInfo: View {
                     .foregroundStyle(.white)
                     .shadow(color: Color(hex: "#FFF").opacity(0.07), radius: 7)
                 
-                VStack(spacing: 0) {
-                    AttendanceView(attendanceCount)
-                    SeatPositionView(seatPosition)
-                    Divider()
-                        .frame(width: 330)
+                if status == ChapelStatus.active {
+                    ActiveStatusView(attendanceCount, seatPosition)
+                } else {
+                    InactiveStatusView()
                 }
             }
             .padding(.top, 14.5)
         }
         .padding(.horizontal, 20)
         .padding(.top, 24.5)
+    }
+}
+
+private struct ActiveStatusView: View {
+    let attendanceCount: Int
+    let seatPosition: String
+    
+    init(_ attendanceCount: Int, _ seatPosition: String) {
+        self.attendanceCount = attendanceCount
+        self.seatPosition = seatPosition
+    }
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            AttendanceView(attendanceCount)
+            SeatPositionView(seatPosition)
+            Divider()
+                .frame(width: 330)
+        }
+    }
+}
+
+private struct InactiveStatusView: View {
+    var body: some View {
+        Text("채플 수료 완료!")
+            .font(.system(size: 18))
+            .foregroundStyle(mainPurple)
     }
 }
 
@@ -59,7 +86,9 @@ private struct AttendanceView: View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
                 Text("Pass까지 ")
+                    .font(.system(size: 15))
                 + Text("\(remainToPassCount)회 ")
+                    .font(.system(size: 15))
                     .foregroundStyle(mainPurple)
                 + Text("남았어요")
                     .font(.system(size: 15))
@@ -137,7 +166,14 @@ private struct CustomLinearProgressViewStyle: ProgressViewStyle {
 }
 
 #Preview {
-    ChapelInfo(chapelCard: ChapelCard(attendance: 4, seatPosition: "E-10-4"))
+    ZStack {
+        Color(.lightGray)
+            .ignoresSafeArea(.all)
+        VStack {
+            ChapelInfo(chapelCard: ChapelCard(attendance: 4, seatPosition: "E-10-4"))
+            ChapelInfo(chapelCard: ChapelCard.inactive())
+        }
+    }
 }
 
 

--- a/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
@@ -1,0 +1,104 @@
+//
+//  ChapelInfo.swift
+//  Soomsil-USaint
+//
+//  Created by 서준영 on 5/26/25.
+//
+
+import SwiftUI
+
+struct Chapel: View {
+    var seatPos: String = "1층 A-1-2"
+    var attendanceNum: Int = 8
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("채플")
+                .font(.system(size: 18, weight: .bold))
+                .lineSpacing(5.4) // 130% line height 계산: 18 * 0.3 = 5.4
+                .kerning(0) // Letter spacing 0%
+                .foregroundStyle(Color(hex: "#101112"))
+                .frame(width: 32, height: 23)
+            ZStack {
+                Rectangle()
+                    .frame(width: 350, height: 110)
+                    .cornerRadius(16)
+                    .foregroundStyle(.white)
+                    .shadow(color: Color(hex: "#69603B").opacity(0.07), radius: 7)
+                VStack(spacing: 0) {
+                    HStack(spacing: 0) {
+                        Text("내 좌석")
+                            .font(.system(size: 15))
+                            .padding(.leading, 28)
+                        Spacer()
+                        Text(seatPos)
+                            .font(.system(size: 16))
+                            .fontWeight(.bold)
+                            .foregroundStyle(Color(hex: "#816DEC"))
+                            .padding(.trailing, 28)
+                    }
+                    .frame(width: 350, height: 37)
+                    
+                    HStack(spacing: 0) {
+                        Text("출결 정보")
+                            .font(.system(size: 15))
+                            .padding(.leading, 28)
+                        Spacer()
+                        Text("\(attendanceNum)")
+                            .font(.system(size: 16))
+                            .fontWeight(.bold)
+                            .foregroundStyle(Color(hex: "#816DEC"))
+                        Text(" / 12")
+                            .font(.system(size: 10))
+                            .padding(.trailing, 28)
+                            .foregroundStyle(Color(hex: "#8E9398"))
+                            .offset(y: 2)
+                    }
+                    .frame(width: 350, height: 37)
+                }
+                Rectangle() // Divider
+                    .foregroundStyle(Color(hex: "#101112").opacity(0.1))
+                    .frame(width: 330, height: 0.34)
+            }
+            .padding(.top, 14.5)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 24.5)
+    }
+}
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 3: // RGB (12-bit)
+            (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+        case 6: // RGB (24-bit)
+            (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+        case 8: // ARGB (32-bit)
+            (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (1, 1, 1, 0)
+        }
+        
+        self.init(
+            .sRGB,
+            red: Double(r) / 255,
+            green: Double(g) / 255,
+            blue:  Double(b) / 255,
+            opacity: Double(a) / 255
+        )
+    }
+}
+
+
+#Preview {
+    ZStack {
+        Color.yellow
+            .edgesIgnoringSafeArea(.all)
+        Chapel()
+    }
+}

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -28,6 +28,9 @@ struct HomeView: View {
                     } onSemesterDetailPressed: {
                         store.send(.semesterDetailPressed)
                     }
+                    
+                    Chapel()
+                    
                     Spacer()
                 }
                 .padding(.horizontal, 16)

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -29,7 +29,7 @@ struct HomeView: View {
                         store.send(.semesterDetailPressed)
                     }
                     
-                    ChapelInfo()
+                    ChapelInfo(chapelCard: ChapelCard(attendance: store.chapelCard.attendance, seatPosition: store.chapelCard.seatPosition))
                     
                     Spacer()
                 }
@@ -104,7 +104,7 @@ private extension HomeView {
     HomeView(store: Store(
         initialState: HomeReducer.State(
             studentInfo: StudentInfo(name: "000", major: "글로벌미디어학부", schoolYear: "6학년"),
-            totalReportCard: TotalReportCard(gpa: 3.4, earnedCredit: 34.5, graduateCredit: 124.0)
+            totalReportCard: TotalReportCard(gpa: 3.4, earnedCredit: 34.5, graduateCredit: 124.0), chapelCard: ChapelCard(attendance: 4, seatPosition: "E-10-4")
         )
     ) {
         HomeReducer()

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -29,7 +29,7 @@ struct HomeView: View {
                         store.send(.semesterDetailPressed)
                     }
                     
-                    ChapelInfo(chapelCard: ChapelCard(attendance: store.chapelCard.attendance, seatPosition: store.chapelCard.seatPosition))
+                    ChapelInfo(chapelCard: ChapelCard(attendance: store.chapelCard.attendance, seatPosition: store.chapelCard.seatPosition, status: store.chapelCard.status))
                     
                     Spacer()
                 }

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -29,7 +29,11 @@ struct HomeView: View {
                         store.send(.semesterDetailPressed)
                     }
                     
-                    ChapelInfo(chapelCard: ChapelCard(attendance: store.chapelCard.attendance, seatPosition: store.chapelCard.seatPosition, status: store.chapelCard.status))
+                    ChapelInfo(chapelCard: ChapelCard(
+                        attendance: store.chapelCard.attendance,
+                        seatPosition: store.chapelCard.seatPosition,
+                        floorLevel: store.chapelCard.floorLevel,
+                        status: store.chapelCard.status))
                     
                     Spacer()
                 }
@@ -104,7 +108,7 @@ private extension HomeView {
     HomeView(store: Store(
         initialState: HomeReducer.State(
             studentInfo: StudentInfo(name: "000", major: "글로벌미디어학부", schoolYear: "6학년"),
-            totalReportCard: TotalReportCard(gpa: 3.4, earnedCredit: 34.5, graduateCredit: 124.0), chapelCard: ChapelCard(attendance: 4, seatPosition: "E-10-4")
+            totalReportCard: TotalReportCard(gpa: 3.4, earnedCredit: 34.5, graduateCredit: 124.0), chapelCard: ChapelCard(attendance: 4, seatPosition: "E-10-4", floorLevel: 1)
         )
     ) {
         HomeReducer()

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -29,7 +29,7 @@ struct HomeView: View {
                         store.send(.semesterDetailPressed)
                     }
                     
-                    Chapel()
+                    ChapelInfo()
                     
                     Spacer()
                 }

--- a/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
@@ -55,8 +55,12 @@ struct LoginReducer {
                         try await studentClient.setStudentInfo()
                         let rusaintReport = try await gradeClient.fetchTotalReportCard()
                         try await gradeClient.updateTotalReportCard(rusaintReport)
-                        let  chapelReport = try await chapelClient.fetchChapelCard()
-                        try await chapelClient.updateChapelCard(chapelReport)
+                        do {
+                            let chapelReport = try await chapelClient.fetchChapelCard()
+                            try await chapelClient.updateChapelCard(chapelReport)
+                        } catch {
+                            debugPrint("fetchCahpelCard() error \(error)")
+                        }
 
                         let studentInfo = try await studentClient.getStudentInfo()
                         let report = try await gradeClient.getTotalReportCard()

--- a/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
@@ -24,12 +24,13 @@ struct LoginReducer {
         case onAppear
         case initResponse(Result<SaintInfo, Error>)
         case loginPressed
-        case loginResponse(Result<(StudentInfo, TotalReportCard), Error>)
+        case loginResponse(Result<(StudentInfo, TotalReportCard, ChapelCard), Error>)
         case deleteResponse(Result<Void, Error>)
     }
     
     @Dependency(\.gradeClient) var gradeClient
     @Dependency(\.studentClient) var studentClient
+    @Dependency(\.chapelClient) var chapelClient
     
     var body: some Reducer<State, Action> {
         BindingReducer()
@@ -54,11 +55,14 @@ struct LoginReducer {
                         try await studentClient.setStudentInfo()
                         let rusaintReport = try await gradeClient.fetchTotalReportCard()
                         try await gradeClient.updateTotalReportCard(rusaintReport)
+                        let  chapelReport = try await chapelClient.fetchChapelCard()
+                        try await chapelClient.updateChapelCard(chapelReport)
 
                         let studentInfo = try await studentClient.getStudentInfo()
                         let report = try await gradeClient.getTotalReportCard()
+                        let chapel = try await chapelClient.getChapelCard()
                         
-                        return (studentInfo, report)
+                        return (studentInfo, report, chapel)
                     }))
                 }
             case .loginResponse(.success):

--- a/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
@@ -55,16 +55,24 @@ struct LoginReducer {
                         try await studentClient.setStudentInfo()
                         let rusaintReport = try await gradeClient.fetchTotalReportCard()
                         try await gradeClient.updateTotalReportCard(rusaintReport)
+                        
+                        var chapel: ChapelCard
                         do {
                             let chapelReport = try await chapelClient.fetchChapelCard()
                             try await chapelClient.updateChapelCard(chapelReport)
+                            chapel = try await chapelClient.getChapelCard()
+                        } catch ChapelError.noChapelData {
+                            chapel = ChapelCard.inactive()
+                        } catch ChapelError.networkError {
+                            print("네트워크 에러")
+                            chapel = try await chapelClient.getChapelCard()
                         } catch {
-                            debugPrint("fetchCahpelCard() error \(error)")
+                            print("채플 정보 조회 중 알 수 없는 오류: \(error)")
+                            chapel = try await chapelClient.getChapelCard()
                         }
 
                         let studentInfo = try await studentClient.getStudentInfo()
                         let report = try await gradeClient.getTotalReportCard()
-                        let chapel = try await chapelClient.getChapelCard()
                         
                         return (studentInfo, report, chapel)
                     }))

--- a/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
@@ -43,6 +43,7 @@ struct SettingReducer {
     @Dependency(\.localNotificationClient) var localNotificationClient
     @Dependency(\.studentClient) var studentClient
     @Dependency(\.gradeClient) var gradeClient
+    @Dependency(\.chapelClient) var chapelClient
     @Dependency(\.dismiss) var dismiss
 
     var body: some ReducerOf<Self> {
@@ -80,6 +81,7 @@ struct SettingReducer {
                     try await gradeClient.deleteTotalReportCard()
                     try await gradeClient.deleteAllSemesterGrades()
                     try await studentClient.deleteStudentInfo()
+                    try await chapelClient.deleteChapelCard()
 
                     YDSToast("로그아웃 완료", haptic: .success)
 

--- a/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
@@ -21,7 +21,7 @@ struct SplashReducer {
         case checkMinimumVersion
         case checkMinimumVersionResponse(Result<String, Error>)
         case initialize
-        case initResponse(Result<(StudentInfo, TotalReportCard), Error>)
+        case initResponse(Result<(StudentInfo, TotalReportCard, ChapelCard), Error>)
         
         enum Alert: Equatable {
             case confirmTapped
@@ -32,6 +32,7 @@ struct SplashReducer {
     @Dependency(\.remoteConfigClient) var remoteConfigClient
     @Dependency(\.gradeClient) var gradeClient
     @Dependency(\.studentClient) var studentClient
+    @Dependency(\.chapelClient) var chapelClient
     @Dependency(\.openURL) var openURL
     
     var body: some Reducer<State, Action> {
@@ -85,7 +86,8 @@ struct SplashReducer {
                     await send(.initResponse(Result {
                         let info = try await studentClient.getStudentInfo()
                         let card = try await gradeClient.getTotalReportCard()
-                        return (info, card)
+                        let chapel = try await chapelClient.getChapelCard()
+                        return (info, card, chapel)
                     }))
                 }
             default:

--- a/Soomsil-USaint/Data/Client/RuSaint/ChapelClient.swift
+++ b/Soomsil-USaint/Data/Client/RuSaint/ChapelClient.swift
@@ -57,8 +57,9 @@ extension ChapelClient: DependencyKey {
                 // 5. ChapelCard 생성
                 let attendanceCount = chapelInfo.attendances.filter { $0.attendance == "출석" }.count
                 let seatPosition = chapelInfo.generalInformation.seatNumber
+                let floorLevel = chapelInfo.generalInformation.floorLevel
                 
-                return ChapelCard(attendance: attendanceCount, seatPosition: seatPosition)
+                return ChapelCard(attendance: attendanceCount, seatPosition: seatPosition, floorLevel: floorLevel)
             } catch let error as ChapelError {
                 print("catch: error as ChapelError")
                 throw error
@@ -89,7 +90,7 @@ extension ChapelClient: DependencyKey {
             do {
                 let data = try context.fetch(fetchRequest)
                 guard let first = data.first else {
-                    return ChapelCard(attendance: 0, seatPosition: "정보 없음", status: .inactive)
+                    return ChapelCard(attendance: 0, seatPosition: "정보 없음", floorLevel: 0, status: .inactive)
                 }
                 
                 let statusString = first.status ?? "active"
@@ -98,11 +99,12 @@ extension ChapelClient: DependencyKey {
                 return ChapelCard(
                     attendance: Int(first.attendance),
                     seatPosition: first.seatPosition ?? "정보 없음",
+                    floorLevel: UInt32(first.floorLevel),
                     status: status
                 )
             } catch {
                 print("ChapelCard 조회 실패: \(error.localizedDescription)")
-                return ChapelCard(attendance: 0, seatPosition: "정보 없음")
+                return ChapelCard(attendance: 0, seatPosition: "정보 없음", floorLevel: 0)
             }
         }, updateChapelCard: { chapelCard in
             let context = coreDataStack.taskContext()
@@ -115,6 +117,7 @@ extension ChapelClient: DependencyKey {
             let cdChapelCard = CDChapelCard(context: context)
             cdChapelCard.attendance = Int32(chapelCard.attendance)
             cdChapelCard.seatPosition = chapelCard.seatPosition
+            cdChapelCard.floorLevel = Int32(chapelCard.floorLevel)
             cdChapelCard.status = chapelCard.status == .active ? "active" : "inactive"
             
             context.performAndWait {
@@ -135,9 +138,9 @@ extension ChapelClient: DependencyKey {
     
     static let previewValue: ChapelClient = Self(
         fetchChapelCard: {
-            return ChapelCard(attendance: 2, seatPosition: "E-10-4")
+            return ChapelCard(attendance: 2, seatPosition: "E-10-4", floorLevel: 1)
         }, getChapelCard: {
-            ChapelCard(attendance: 10, seatPosition: "A-3-2")
+            ChapelCard(attendance: 10, seatPosition: "A-3-2", floorLevel: 1)
         }, updateChapelCard: { chapelCard in
             return
         }, deleteChapelCard: {

--- a/Soomsil-USaint/Data/Client/RuSaint/ChapelClient.swift
+++ b/Soomsil-USaint/Data/Client/RuSaint/ChapelClient.swift
@@ -1,0 +1,50 @@
+//
+//  ChapelClient.swift
+//  Soomsil-USaint
+//
+//  Created by 서준영 on 6/1/25.
+//
+
+import CoreData
+import ComposableArchitecture
+import Rusaint
+
+@DependencyClient
+struct ChapelClient {
+    static let coreDataStack: CoreDataStack = .shared
+    
+    var fetchChapelCard: @Sendable () async throws -> ChapelCard
+    
+    var getChapelCard: @Sendable () async throws -> ChapelCard
+    
+    var updateChapelCard: @Sendable (_ chapelCard: ChapelCard) async throws -> Void
+    
+    var deleteChapelCard: @Sendable () async throws -> Void
+}
+
+extension DependencyValues {
+    var chapelClient: ChapelClient {
+        get { self[ChapelClient.self] }
+        set { self[ChapelClient.self] = newValue }
+    }
+}
+
+extension ChapelClient: DependencyKey {
+    static var liveValue: ChapelClient {
+        <#code#>
+    }
+    
+    static let previewValue: ChapelClient = Self(
+        fetchChapelCard: {
+            return ChapelCard(attendance: 2, seatPosition: "E-10-4")
+        }, getChapelCard: {
+            ChapelCard(attendance: 10, seatPosition: "A-3-2")
+        }, updateChapelCard: { chapelCard in
+            return
+        }, deleteChapelCard: {
+            return
+        }
+    )
+    
+    static let testValue: ChapelClient = previewValue
+}

--- a/Soomsil-USaint/Data/CoreData/SaintModel.xcdatamodel/contents
+++ b/Soomsil-USaint/Data/CoreData/SaintModel.xcdatamodel/contents
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="24A335" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="CDChapelCard" representedClassName="CDChapelCard" syncable="YES" codeGenerationType="class">
+        <attribute name="attendance" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="seatPosition" optional="YES" attributeType="String"/>
+    </entity>
     <entity name="CDLecture" representedClassName="CDLecture" syncable="YES" codeGenerationType="class">
         <attribute name="code" optional="YES" attributeType="String"/>
         <attribute name="credit" optional="YES" attributeType="Float" defaultValueString="0.0" usesScalarValueType="YES"/>

--- a/Soomsil-USaint/Data/CoreData/SaintModel.xcdatamodel/contents
+++ b/Soomsil-USaint/Data/CoreData/SaintModel.xcdatamodel/contents
@@ -3,6 +3,7 @@
     <entity name="CDChapelCard" representedClassName="CDChapelCard" syncable="YES" codeGenerationType="class">
         <attribute name="attendance" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="seatPosition" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
     </entity>
     <entity name="CDLecture" representedClassName="CDLecture" syncable="YES" codeGenerationType="class">
         <attribute name="code" optional="YES" attributeType="String"/>

--- a/Soomsil-USaint/Data/CoreData/SaintModel.xcdatamodel/contents
+++ b/Soomsil-USaint/Data/CoreData/SaintModel.xcdatamodel/contents
@@ -2,6 +2,7 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="CDChapelCard" representedClassName="CDChapelCard" syncable="YES" codeGenerationType="class">
         <attribute name="attendance" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="floorLevel" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="seatPosition" optional="YES" attributeType="String"/>
         <attribute name="status" optional="YES" attributeType="String"/>
     </entity>

--- a/Soomsil-USaint/Data/Model/ChapelCard.swift
+++ b/Soomsil-USaint/Data/Model/ChapelCard.swift
@@ -7,7 +7,21 @@
 
 import Foundation
 
+enum ChapelStatus {
+    case active
+    case inactive // 채플을 수강하지 않음
+}
+
 public struct ChapelCard: Hashable {
     let attendance: Int
     let seatPosition: String
+    var status: ChapelStatus = .active
+    
+    static func inactive() -> ChapelCard {
+        return ChapelCard(
+            attendance: 0,
+            seatPosition: "이번 학기 채플 수강 없음",
+            status: .inactive
+        )
+    }
 }

--- a/Soomsil-USaint/Data/Model/ChapelCard.swift
+++ b/Soomsil-USaint/Data/Model/ChapelCard.swift
@@ -9,18 +9,20 @@ import Foundation
 
 enum ChapelStatus {
     case active
-    case inactive // 채플을 수강하지 않음
+    case inactive
 }
 
 public struct ChapelCard: Hashable {
     let attendance: Int
     let seatPosition: String
+    let floorLevel: UInt32
     var status: ChapelStatus = .active
     
     static func inactive() -> ChapelCard {
         return ChapelCard(
             attendance: 0,
             seatPosition: "이번 학기 채플 수강 없음",
+            floorLevel: 0,
             status: .inactive
         )
     }

--- a/Soomsil-USaint/Data/Model/ChapelCard.swift
+++ b/Soomsil-USaint/Data/Model/ChapelCard.swift
@@ -1,0 +1,13 @@
+//
+//  ChapelCard.swift
+//  Soomsil-USaint
+//
+//  Created by 서준영 on 6/1/25.
+//
+
+import Foundation
+
+public struct ChapelCard: Hashable {
+    let attendance: Int
+    let seatPosition: String
+}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
홈화면에 채플 뷰 추가했습니다.
TCA 패턴 적용해서 네트워크 연결했습니다.
추가한 파일
- ChapelClient
- ChapelCard
- ChapelInfo

❗️**폰트 디자인시스템이 나오면 수정이 필요합니다.**

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #117 
- 피그마 : 
- 관련 문서 :
- close: 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 폰트는 임시로 지정해 놓았습니다.
- Pass까지 남은 횟수가 0보다 작아지지 않도록 했습니다.
- [x] 채플을 수강하지 않는 학생이 로그인 되도록 수정했습니다.
- [x] 채플을 수강하지 않는 학생과 네트워크 에러를 구분하도록 수정했습니다.
- [x] 색상 디자인 시스템을 적용 했습니다.
- [x] 최신 피그마에 맞게 뷰를 수정했습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
<img width="281" alt="스크린샷 2025-06-18 오후 11 01 00" src="https://github.com/user-attachments/assets/8bced745-e4b9-4d38-8c92-19f687553fd5" />

## 🔥 Test
<!-- Test -->
<img width="306" alt="스크린샷 2025-06-18 오후 10 57 24" src="https://github.com/user-attachments/assets/24b9d106-5908-498b-a4ac-f8e5c8e94268" />

