### PR TITLE
[#129] SemesterDetailView 및 연관 Reducer / Client 수정

### DIFF
--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/Core/SemesterDetailReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/Core/SemesterDetailReducer.swift
@@ -36,7 +36,7 @@ struct SemesterDetailReducer {
             case .onAppear:
                 return .run { send in
                     await send(.semesterListResponse(Result {
-                        try await gradeClient.getAllSemesterGrades()
+                        try await gradeClient.fetchAllSemesterGrades()
                     }))
                 }
             case .refresh:
@@ -46,8 +46,9 @@ struct SemesterDetailReducer {
                     await dismiss()
                 }
             case .semesterListResponse(.success(let semesterList)):
-                state.semesterList = semesterList
-                state.tabs = semesterList.map {
+                let descendingList = semesterList.sortedDescending()
+                state.semesterList = descendingList
+                state.tabs = descendingList.map {
                     SemesterTab(id: "\($0.year)년 \($0.semester)")
                 }
                 state.activeTab = state.tabs.first?.id ?? ""

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
@@ -20,6 +20,9 @@ struct SemesterDetailView: View {
     var body: some View {
 
         VStack(spacing: 0) {
+            GPAGraphView(semesterList: store.semesterList)
+                .padding(.horizontal, 17.5)
+
             TabView(tabs: $store.tabs,
                     activeTab: $store.activeTab,
                     mainViewScrollState: $mainViewScrollState,

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
@@ -70,14 +70,32 @@ struct SemesterDetailView: View {
                 }
             }
         }
+        .overlay(
+            store.isLoading ? CircleLoadingView() : nil
+        )
         .onAppear() {
             store.send(.onAppear)
         }
         .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
-                BackButton {
-                    store.send(.backButtonTapped)
+                HStack(spacing: 0) {
+                    BackButton {
+                        store.send(.backButtonTapped)
+                    }
+                    Text("성적")
+                        .font(.system(size: 20, weight: .bold))
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    Task {
+                        store.send(.refreshButtonTapped)
+                    }
+                } label: {
+                    YDSIcon.refreshLine
+                        .renderingMode(.template)
+                        .foregroundStyle(.grayText)
                 }
             }
         }

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterList/Core/SemesterListReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterList/Core/SemesterListReducer.swift
@@ -39,6 +39,7 @@ struct SemesterListReducer {
             switch action {
             case .onAppear:
                 return .run { send in
+
                     await send(.totalReportCardResponse(Result {
                         return try await gradeClient.getTotalReportCard()
                     }))
@@ -101,5 +102,4 @@ struct SemesterListReducer {
         let allSemesterGrades = try await gradeClient.fetchAllSemesterGrades()
         try await gradeClient.updateAllSemesterGrades(allSemesterGrades)
     }
-
 }

--- a/Soomsil-USaint/Global/Utils/String+.swift
+++ b/Soomsil-USaint/Global/Utils/String+.swift
@@ -1,0 +1,24 @@
+//
+//  String+.swift
+//  Soomsil-USaint
+//
+//  Created by 박현수 on 6/24/25.
+//
+
+import Foundation
+
+import Rusaint
+
+extension String {
+    func toSemesterType() -> SemesterType {
+        switch self {
+        case "1 학기": return .one
+        case "2 학기": return .two
+        case "여름학기": return .summer
+        case "겨울학기": return .winter
+        default:
+            debugPrint("\(#function) | Unsupported semester type \(self), 1학기로 매핑됩니다.")
+            return .one
+        }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
SemesterDetailView 및 연관 Reducer / Client 수정
### `SemesterDetailView` 상단 `GPAGraphView` 추가
- 상단 그래프는 컴포넌트화 되어 있는 것 같아서, SemesterDetailView 상단에 추가했습니다.
### 탭 선택 Descending Order 보장
- 탭 선택 UI가 내림차순으로 정렬되도록 로직 수정했습니다.
### `GradeClient` `fetchAllSemesterGrades` 수정
- 각 GradeSummary가 lectures 프로퍼티를 들고 있도록 수정했습니다.
## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #128
- 피그마 : 
- 관련 문서 :
- close:

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
### `GPAGraphView` 디자인
- GPAGraphView 컴포넌트가 Horizontal Padding, 하단 '계절학기 포함' 버튼 등 피그마 상 UI 디자인과 상이한 점들이 있습니다.
  - 해당 뷰에서만 다른 디자인으로 적용되는 건지, 아니면 컴포넌트 디자인 자체가 바뀐 건지 모르겠어서 일단 수정하지 않았습니다.
  - 현 SemesterDetailView UI 디자인에 맞게 GPAGraphView를 수정해도 될까요?
### `TabView` Descending Order 보장
- 전달받았던 대로, semester를 정렬하는 메소드(`sortedDescending`)가 사전 정의되어 있어 해당 메소드 사용했습니다.
### `GradeClient` `fetchAllSemesterGrades` 수정
- `fetchAllSemesterGrades` 메소드에서 `SemesterGrade` -> `GradeSummary` 매핑 시 lecture 정보를 가져올 프로퍼티가 `SemesterGrade`에 없어, lectures에 nil이 들어가고 있는 것을 확인했습니다.
  - 각 학기의 LectureDetail 정보를 TaskGroup을 통해 병렬적으로 fetch하여, lectures를 넣어 주도록 수정했습니다.
  - 기존 SemesterListReducer와 같이 onappear 상태에서는 CoreData에서 데이터를를 가져오고, 새로고침 버튼 클릭 시 fetch 후 CoreData에 저장하도록 수정했습니다.
    - 애플리케이션 전역 스코프에서 데이터를 fetch하는 로직이 따로 작성되어 있나요? SemesterDetailView에서 새로고침 버튼을 누르기 전까지는 CoreData에 저장된 데이터가 따로 없는 것 같습니다!
 
## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
https://github.com/user-attachments/assets/45ecb7fc-c979-4a93-8e8f-3d4d5c55b0d1


## 🔥 Test
<!-- Test -->
