### PR TITLE
[#137] SemesterDetailView ProgressView 추가 및 폰트 수정 | SemesterDetailReducer fetch 로직 수정

### DIFF
--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/Core/SemesterDetailReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/Core/SemesterDetailReducer.swift
@@ -56,6 +56,20 @@ struct SemesterDetailReducer {
                     await dismiss()
                 }
             case .semesterListResponse(.success(let semesterList)):
+                guard !semesterList.isEmpty
+                else {
+                    return .run { send in
+                        do {
+                            try await refreshGradeData()
+                            await send(.semesterListResponse(.success(
+                                try await gradeClient.getAllSemesterGrades()
+                            )))
+                        } catch {
+                            await send(.semesterListResponse(.failure(error)))
+                        }
+                    }
+                }
+
                 let descendingList = semesterList.sortedDescending()
                 state.semesterList = descendingList
                 state.tabs = descendingList.map {

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/Core/SemesterDetailReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/Core/SemesterDetailReducer.swift
@@ -75,7 +75,7 @@ struct SemesterDetailReducer {
                 state.tabs = descendingList.map {
                     SemesterTab(id: "\($0.year)년 \($0.semester)")
                 }
-                state.activeTab = state.tabs.first?.id ?? ""
+                if state.activeTab.isEmpty { state.activeTab = state.tabs.first?.id ?? "" }
                 state.isLoading = false
                 return .none
             case .semesterListResponse(.failure(let error)):

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/GradeOverView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/GradeOverView.swift
@@ -22,17 +22,17 @@ struct GradeOverView: View {
     }
     
     var body: some View {
-        HStack {
+        HStack(alignment: .firstTextBaseline) {
             Text(transformIfZero(title))
-                .font(YDSFont.body1)
+                .font(.custom("AppleSDGothicNeo-Regular", size: 15))
                 .foregroundStyle(.grayText)
             Spacer()
             Text(transformIfZero(accentText))
-                .font(YDSFont.subtitle2)
+                .font(.custom("AppleSDGothicNeo-Bold", size: 16))
                 .foregroundStyle(.titleText)
             if let subText {
                 Text("/ \(transformIfZero(subText))")
-                    .font(YDSFont.caption0)
+                    .font(.custom("AppleSDGothicNeo-Bold", size: 12))
                     .foregroundStyle(.grayText)
             }
         }

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/GradeRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/GradeRowView.swift
@@ -32,10 +32,10 @@ struct GradeRowView: View {
             
             VStack(alignment: .leading, spacing: 3) {
                 Text(title)
-                    .font(YDSFont.subtitle2)
+                    .font(.custom("AppleSDGothicNeo-Bold", size: 16))
                     .foregroundStyle(.titleText)
                 Text("\(professorName) · \(String(format: "%.1f", credit)) 학점")
-                    .font(YDSFont.body2)
+                    .font(.custom("AppleSDGothicNeo-Regular", size: 14))
                     .foregroundStyle(.grayText)
             }
             Spacer()

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
@@ -86,7 +86,7 @@ struct SemesterDetailView: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button {
-                    store.send(\.backButtonTapped)
+                    store.send(.backButtonTapped)
                 } label: {
                     HStack(spacing: 0) {
                         Image("ic_arrow_left_line")

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
@@ -36,10 +36,9 @@ struct SemesterDetailView: View {
 
                 GeometryReader {
                     let size = $0.size
-
                     ScrollView(.horizontal) {
-                        LazyHStack(spacing: 0) {
 
+                        LazyHStack(spacing: 0) {
                             ForEach(store.tabs) { tab in
                                 ScrollView(.vertical) {
                                     let tappedSemester = findTappedSemester(
@@ -168,7 +167,7 @@ extension SemesterDetailView {
         var body: some View {
             ScrollView(.horizontal) {
                 HStack(spacing: 0) {
-                    ForEach($tabs) { $tab in
+                    ForEach($tabs, id: \.uuid) { $tab in
                         Button {
                             withAnimation(.snappy) {
                                 activeTab = tab.id
@@ -191,12 +190,7 @@ extension SemesterDetailView {
                 }
                 .scrollTargetLayout()
             }
-            .scrollPosition(id: .init(get: {
-                return tabBarScrollState
-            }, set: { _ in
-
-            }), anchor: .center)
-
+            .scrollPosition(id: $tabBarScrollState, anchor: .center)
             .overlay(alignment: .bottom) {
                 ZStack(alignment: .leading) {
                     Rectangle()

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
@@ -88,7 +88,7 @@ struct SemesterDetailView: View {
                 Button {
                     store.send(.backButtonTapped)
                 } label: {
-                    HStack(spacing: 0) {
+                    HStack(spacing: 5) {
                         Image("ic_arrow_left_line")
                             .resizable()
                             .frame(width: 19, height: 19)

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
@@ -20,52 +20,58 @@ struct SemesterDetailView: View {
     var body: some View {
 
         VStack(spacing: 0) {
-            GPAGraphView(semesterList: store.semesterList)
-                .padding(.horizontal, 17.5)
+            if store.semesterList.isEmpty {
+                ProgressView("성적을 불러오는 중입니다")
+                    .tint(.vPrimary)
+                    .controlSize(.large)
+            } else {
+                GPAGraphView(semesterList: store.semesterList)
+                    .padding(.horizontal, 17.5)
 
-            TabView(tabs: $store.tabs,
-                    activeTab: $store.activeTab,
-                    mainViewScrollState: $mainViewScrollState,
-                    tabBarScrollState: $tabBarScrollState,
-                    progress: $progress)
+                TabView(tabs: $store.tabs,
+                        activeTab: $store.activeTab,
+                        mainViewScrollState: $mainViewScrollState,
+                        tabBarScrollState: $tabBarScrollState,
+                        progress: $progress)
 
-            GeometryReader {
-                let size = $0.size
+                GeometryReader {
+                    let size = $0.size
 
-                ScrollView(.horizontal) {
-                    LazyHStack(spacing: 0) {
+                    ScrollView(.horizontal) {
+                        LazyHStack(spacing: 0) {
 
-                        ForEach(store.tabs) { tab in
-                            ScrollView(.vertical) {
-                                let tappedSemester = findTappedSemester(
-                                    semesterList: store.semesterList,
-                                    tabId: tab.id
-                                )
-                                if let semester = tappedSemester {
-                                    TopSummary(gradeSummary: semester)
-                                    GradeList(lectures: semester.lectures ?? [])
+                            ForEach(store.tabs) { tab in
+                                ScrollView(.vertical) {
+                                    let tappedSemester = findTappedSemester(
+                                        semesterList: store.semesterList,
+                                        tabId: tab.id
+                                    )
+                                    if let semester = tappedSemester {
+                                        TopSummary(gradeSummary: semester)
+                                        GradeList(lectures: semester.lectures ?? [])
+                                    }
                                 }
+                                .padding(20)
+                                .frame(width: size.width, height: size.height)
+                                .contentShape(.rect)
                             }
-                            .padding(20)
-                            .frame(width: size.width, height: size.height)
-                            .contentShape(.rect)
+                        }
+                        .scrollTargetLayout()
+                        .rect { rect in
+                            progress = -rect.minX / size.width
                         }
                     }
-                    .scrollTargetLayout()
-                    .rect { rect in
-                        progress = -rect.minX / size.width
-                    }
                 }
-            }
-            .scrollPosition(id: $mainViewScrollState)
-            .scrollIndicators(.hidden)
-            .scrollTargetBehavior(.paging)
-            .onChange(of: mainViewScrollState) { oldValue, newValue in
-                if let newValue {
-                    debugPrint(newValue)
-                    withAnimation(.snappy) {
-                        tabBarScrollState = newValue
-                        store.activeTab = newValue
+                .scrollPosition(id: $mainViewScrollState)
+                .scrollIndicators(.hidden)
+                .scrollTargetBehavior(.paging)
+                .onChange(of: mainViewScrollState) { oldValue, newValue in
+                    if let newValue {
+                        debugPrint(newValue)
+                        withAnimation(.snappy) {
+                            tabBarScrollState = newValue
+                            store.activeTab = newValue
+                        }
                     }
                 }
             }
@@ -79,12 +85,16 @@ struct SemesterDetailView: View {
         .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
-                HStack(spacing: 0) {
-                    BackButton {
-                        store.send(.backButtonTapped)
+                Button {
+                    store.send(\.backButtonTapped)
+                } label: {
+                    HStack(spacing: 0) {
+                        Image("ic_arrow_left_line")
+                            .resizable()
+                            .frame(width: 19, height: 19)
+                        Text("성적")
+                            .font(.custom("AppleSDGothicNeo-Bold", size: 20))
                     }
-                    Text("성적")
-                        .font(.system(size: 20, weight: .bold))
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
@@ -108,8 +118,10 @@ struct SemesterDetailView: View {
             VStack(alignment: .leading) {
                 HStack(alignment: .lastTextBaseline) {
                     Text(String(format: "%.2f", gradeSummary.gpa))
-                        .font(YDSFont.display1)
+                        .font(.custom("AppleSDGothicNeo-Bold", size: 40))
+                        .offset(x: 0, y: -6)
                     Text("/ 4.50")
+                        .font(.custom("AppleSDGothicNeo-Medium", size: 16))
                         .foregroundStyle(.grayText)
                 }
                 GradeOverView(title: "취득 학점",
@@ -117,9 +129,6 @@ struct SemesterDetailView: View {
                 GradeOverView(title: "학기별 석차",
                                 accentText: "\(gradeSummary.semesterRank)",
                                 subText: "\(gradeSummary.semesterStudentCount)")
-                GradeOverView(title: "전체 석차",
-                                accentText: "\(gradeSummary.overallRank)",
-                                subText: "\(gradeSummary.overallStudentCount)")
                 Divider()
             }
         }
@@ -157,18 +166,18 @@ extension SemesterDetailView {
 
         var body: some View {
             ScrollView(.horizontal) {
-                HStack(spacing: 20) {
+                HStack(spacing: 0) {
                     ForEach($tabs) { $tab in
-                        Button(action: {
+                        Button {
                             withAnimation(.snappy) {
                                 activeTab = tab.id
                                 tabBarScrollState = tab.id
                                 mainViewScrollState = tab.id
                             }
-                        }) {
+                        } label: {
                             Text(formatShortedYear(tab.id))
-                                .font(YDSFont.button2)
-                                .padding(.vertical, 12)
+                                .font(.custom("AppleSDGothicNeo-SemiBold", size: 14))
+                                .padding(12)
                                 .foregroundStyle(activeTab == tab.id ? .primary : Color.gray)
                                 .contentShape(.rect)
                         }

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
@@ -95,6 +95,7 @@ struct SemesterDetailView: View {
                         Text("성적")
                             .font(.custom("AppleSDGothicNeo-Bold", size: 20))
                     }
+                    .foregroundStyle(.titleText)
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterTab.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterTab.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SemesterTab: Identifiable, Hashable, Equatable {
+    let uuid = UUID() // 같은 id(학기 이름)을 가진 SemesterTab이 새로고침 등으로 새로 만들어졌을 때, ForEach가 이 변화를 알게 하기 위한 id입니다.
     var id: String
     var size: CGSize = .zero
     var minX: CGFloat = .zero

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterList/View/GPAGraphView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterList/View/GPAGraphView.swift
@@ -111,16 +111,22 @@ private extension GPAGraphView {
                     }
                 }
             }
+            .chartXScale(range: .plotDimension(startPadding: -16, endPadding: -16))
             .chartYScale(domain: 0...2.5)
             .chartYAxis {
                 AxisMarks(position: .leading, values: ySymbols) { axis in
                     AxisGridLine()
                     AxisValueLabel("\(String(format: "%.1F", ySymbols[axis.index] + 2))")
+                        .font(.custom("AppleSDGothicNeo-Regular", size: 14))
                 }
             }
             .chartXAxis {
                 AxisMarks(values: gpaList.map { $0.semester }) { axis in
-                    AxisValueLabel("\(gpaList[axis.index].shortedSemester)")
+                    AxisValueLabel {
+                        Text("\(gpaList[axis.index].shortedSemester)")
+                            .font(.custom("AppleSDGothicNeo-Regular", size: 14))
+                            .minimumScaleFactor(0.5)
+                    }
                 }
             }
             .frame(height: 183)


### PR DESCRIPTION
SemesterDetailView ProgressView 추가 및 폰트 수정 | SemesterDetailReducer fetch 로직 수정

## 📌 Summary
<!-- PR 요약을 써주세요. -->
- SemesterDetailView 폰트 및 레이아웃 수정했습니다.
- ProgressView 추가했습니다.
  - store.semesterList가 비어 있을 경우 ProgressView가 나타나도록 수정했습니다.
- SemesterDetailReducer fetch 로직 수정
  - 초기 onappear에서 coredata를 통해 데이터를 끌어온 후, 끌어온 데이터가 비어 있으면 fetch하도록 수정했습니다.

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #137
- 피그마 : 
- 관련 문서 :
- close: #137

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 그래프 x축 AxisValueLabel이 학기가 많아질 경우 양 끝단에서 잘리는 현상이 있어 minimumScaleFactor를 주어 해결했습니다.
  - 근데 보기 좋진 않네요.. Chart 영역을 벗어날 수 있는 방법이 있는지 알아보면 좋을 것 같습니다

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
https://github.com/user-attachments/assets/a842d65a-6b19-49f0-86b3-63836954e912


## 🔥 Test
<!-- Test -->
