### PR TITLE
[feat] 개강 이벤트 버튼 구현

### DIFF
--- a/Soomsil-USaint.xcodeproj/project.pbxproj
+++ b/Soomsil-USaint.xcodeproj/project.pbxproj
@@ -328,7 +328,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yourssu.SaintKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -367,7 +367,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 3.1.1;
+				MARKETING_VERSION = 3.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.yourssu.SaintKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Soomsil-USaint.xcodeproj/project.pbxproj
+++ b/Soomsil-USaint.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		7B07475E2E095DDF00A055C7 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 7B07475D2E095DDF00A055C7 /* ComposableArchitecture */; };
 		B96F06662D63882B0047D33D /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = B96F06652D63882B0047D33D /* FirebaseCore */; };
 		B96F06682D63882B0047D33D /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = B96F06672D63882B0047D33D /* FirebaseRemoteConfig */; };
+		E50A23E12E68994B00EB7129 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = E50A23E02E68994B00EB7129 /* Mixpanel */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -59,6 +60,7 @@
 				B96F06662D63882B0047D33D /* FirebaseCore in Frameworks */,
 				02C46D8D2D0F45B200A3E717 /* RxBlocking in Frameworks */,
 				B96F06682D63882B0047D33D /* FirebaseRemoteConfig in Frameworks */,
+				E50A23E12E68994B00EB7129 /* Mixpanel in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -111,6 +113,7 @@
 				B96F06672D63882B0047D33D /* FirebaseRemoteConfig */,
 				7B07475D2E095DDF00A055C7 /* ComposableArchitecture */,
 				7B046DA22E106ECA0051989A /* Rusaint */,
+				E50A23E02E68994B00EB7129 /* Mixpanel */,
 			);
 			productName = "Rusaint-iOS";
 			productReference = 02C46CBE2D0F138700A3E717 /* Soomsil-USaint.app */;
@@ -147,6 +150,7 @@
 				B96F06642D63882B0047D33D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				7B07475C2E095DDF00A055C7 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
 				7B046DA12E106ECA0051989A /* XCRemoteSwiftPackageReference "rusaint-ios" */,
+				E50A23DF2E68994B00EB7129 /* XCRemoteSwiftPackageReference "mixpanel-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 02C46CBF2D0F138700A3E717 /* Products */;
@@ -428,8 +432,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/EATSTEAK/rusaint-ios.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMinorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		7B07475C2E095DDF00A055C7 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
@@ -446,6 +450,14 @@
 			requirement = {
 				kind = upToNextMinorVersion;
 				minimumVersion = 11.8.1;
+			};
+		};
+		E50A23DF2E68994B00EB7129 /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mixpanel/mixpanel-swift";
+			requirement = {
+				branch = master;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -500,6 +512,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B96F06642D63882B0047D33D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseRemoteConfig;
+		};
+		E50A23E02E68994B00EB7129 /* Mixpanel */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E50A23DF2E68994B00EB7129 /* XCRemoteSwiftPackageReference "mixpanel-swift" */;
+			productName = Mixpanel;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Soomsil-USaint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Soomsil-USaint.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3cb427ed57d3ec72b7bfff03c1040d35d0b31299d08cd8c5dc07d00639bdca74",
+  "originHash" : "db92476935e9490d8e09092d8fa0e81314c0bbd69c4c0ae90bd4c9780f1a09cd",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -110,6 +110,15 @@
       }
     },
     {
+      "identity" : "mixpanel-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mixpanel/mixpanel-swift",
+      "state" : {
+        "branch" : "master",
+        "revision" : "7459dd6b61665cce9f4f284ccd5dfd1d902aa568"
+      }
+    },
+    {
       "identity" : "nanopb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/nanopb.git",
@@ -151,7 +160,7 @@
       "location" : "https://github.com/EATSTEAK/rusaint-ios.git",
       "state" : {
         "branch" : "main",
-        "revision" : "6c455443825681569f8bd4cb4f3af8b53c5a64d3"
+        "revision" : "57a60b01912dea997fca50e99f303863b4dbb2b7"
       }
     },
     {

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 import ComposableArchitecture
+import UIKit
 
 @Reducer
 struct HomeReducer {
@@ -233,8 +234,11 @@ struct HomeReducer {
             return .none
         }
 
-        state.path.append(.web(WebReducer.State(url: url)))
-        return .none
+        return .run { _ in
+            await MainActor.run {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            }
+        }
     }
 
 }

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -176,10 +176,7 @@ struct HomeReducer {
                 state.isLoading = false
                 return .none
             case .openGiftLinkPressed:
-                state.path.append(.web(WebReducer.State(
-                    url: URL(string: "https://naver.com")!
-                )))
-                return .none
+                return handleGiftLinkPressed(&state)
             default:
                 return .none
             }
@@ -195,4 +192,32 @@ struct HomeReducer {
         let allSemesterGrades = try await gradeClient.fetchAllSemesterGrades()
         try await gradeClient.updateAllSemesterGrades(allSemesterGrades)
     }
+
+    //MARK: - Events
+
+    private func handleGiftLinkPressed(_ state: inout State) -> Effect<Action> {
+        let student = state.studentInfo
+
+        guard let saintID = StudentClient.keychain["saintID"] else {
+            state.toastMessage = "학번을 불러올 수 없습니다."
+            return .none
+        }
+
+        let baseURL = "https://lottery-one.vercel.app"
+
+        let major = student.major.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let name = student.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let schoolNumber = saintID.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+
+        let fullURLString = "\(baseURL)?major=\(major)&name=\(name)&schoolNumber=\(schoolNumber)"
+
+        guard let url = URL(string: fullURLString) else {
+            state.toastMessage = "복권 페이지 링크를 열 수 없습니다."
+            return .none
+        }
+
+        state.path.append(.web(WebReducer.State(url: url)))
+        return .none
+    }
+
 }

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -52,6 +52,10 @@ struct HomeReducer {
         case getGradeDataResponse(Result<[GradeSummary], Error>)
         case fetchGradeDataResponse(Result<Void, Error>)
         case fetchCurrentSemesterGradeResponse(Result<[LectureDetail], Error>)
+
+        //MARK: - Events
+
+        case openGiftLinkPressed
     }
     
     @Dependency(\.localNotificationClient) var localNotificationClient
@@ -170,6 +174,11 @@ struct HomeReducer {
             case .fetchCurrentSemesterGradeResponse(.failure(let error)):
                 state.toastMessage = String(describing: error)
                 state.isLoading = false
+                return .none
+            case .openGiftLinkPressed:
+                state.path.append(.web(WebReducer.State(
+                    url: URL(string: "https://naver.com")!
+                )))
                 return .none
             default:
                 return .none

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -61,7 +61,8 @@ struct HomeReducer {
     @Dependency(\.localNotificationClient) var localNotificationClient
     @Dependency(\.studentClient) var studentClient
     @Dependency(\.gradeClient) var gradeClient
-    
+    @Dependency(\.mixpanelClient) var mixpanelClient
+
     var body: some Reducer<State, Action> {
         BindingReducer()
         Reduce { state, action in
@@ -120,6 +121,12 @@ struct HomeReducer {
                 state.path.append(.semesterDetail(SemesterDetailReducer.State()))
                 return .none
             case .currentSemesterGradesPressed:
+                let student = state.studentInfo
+                let saintId = Int(StudentClient.keychain["saintID"] ?? "") ?? -1
+
+                let (event, props) = AnalyticsEvent.thisSemesterGradeClick(student: student, saintId: saintId)
+                mixpanelClient.track(event, properties: props)
+
                 state.currentSemesterGrades = true
                 state.isLoading = true
                 return .run { send in
@@ -139,6 +146,16 @@ struct HomeReducer {
                 state.currentSemesterGrades = false
                 return .none
             case .semesterGradesPressed:
+                let student = state.studentInfo
+                let saintId = Int(StudentClient.keychain["saintID"] ?? "") ?? -1
+                let chapel = state.chapelCard.status == .active  
+
+                let (event, props) = AnalyticsEvent.allSemesterGradeClick(
+                    student: student,
+                    saintId: saintId,
+                    chapel: chapel
+                )
+                mixpanelClient.track(event, properties: props)
                 state.path.append(.semesterDetail(SemesterDetailReducer.State()))
                 return .none
             case .getGradeDataResponse(.success(let semesterList)):

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -23,12 +23,18 @@ struct HomeView: View {
                     Student(student: store.studentInfo) {
                         store.send(.settingPressed)
                     }
+//                    ReportCardView(reportCard: store.totalReportCard) {
+//                        store.send(.currentSemesterGradesPressed)
+//                    } onSemesterGradesPressed: {
+//                        store.send(.semesterGradesPressed)
+//                    }
                     ReportCardView(reportCard: store.totalReportCard) {
-                        store.send(.currentSemesterGradesPressed)
-                    } onSemesterGradesPressed: {
                         store.send(.semesterGradesPressed)
+                    } onGiftLinkPressed: {
+                        store.send(.openGiftLinkPressed)
                     }
-                    
+
+
                     ChapelInfo(chapelCard: ChapelCard(
                         attendance: store.chapelCard.attendance,
                         seatPosition: store.chapelCard.seatPosition,

--- a/Soomsil-USaint/Application/Feature/Home/View/ReportCardView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/ReportCardView.swift
@@ -12,9 +12,13 @@ import YDS_SwiftUI
 struct ReportCardView: View {
     var reportCard: TotalReportCard
     
-    let onCurrentSemesterPressed: () -> Void
+    //let onCurrentSemesterPressed: () -> Void
     let onSemesterGradesPressed: () -> Void
-    
+
+    //MARK: - Events
+
+    let onGiftLinkPressed: () -> Void
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("내 성적")
@@ -23,10 +27,11 @@ struct ReportCardView: View {
                 .padding(.bottom, 15)
             
             Button(action: {
-                onCurrentSemesterPressed()
+                onGiftLinkPressed()
             }) {
                 HStack(spacing: 0) {
-                    Text("이번 학기 성적 확인")
+                    //Text("이번 학기 성적 확인")
+                    Text("🎁 개강 선물 도착, 복권 뽑으러 가기!")
                         .foregroundStyle(.titleText)
                         .font(YDSFont.body1)
                         .padding(.vertical, 19)
@@ -87,7 +92,7 @@ struct CreditLine: View {
 }
 
 #Preview {
-    ReportCardView(reportCard: TotalReportCard(gpa: 4.5, earnedCredit: 123, graduateCredit: 188, generalRank: 10, overallStudentCount: 100)) {} onSemesterGradesPressed: {}
+    ReportCardView(reportCard: TotalReportCard(gpa: 4.5, earnedCredit: 123, graduateCredit: 188, generalRank: 10, overallStudentCount: 100)) {} /*onSemesterGradesPressed: {}*/ onGiftLinkPressed: {}
         .background(.navigationBarSurface)
         .padding(.horizontal, 20)
 }

--- a/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
@@ -31,7 +31,8 @@ struct LoginReducer {
     @Dependency(\.gradeClient) var gradeClient
     @Dependency(\.studentClient) var studentClient
     @Dependency(\.chapelClient) var chapelClient
-    
+    @Dependency(\.mixpanelClient) var mixpanelClient
+
     var body: some Reducer<State, Action> {
         BindingReducer()
         Reduce { state, action in
@@ -77,8 +78,13 @@ struct LoginReducer {
                         return (studentInfo, report, chapel)
                     }))
                 }
-            case .loginResponse(.success):
+            case .loginResponse(.success(let (studentInfo, _, _))):
                 state.isLoading = false
+
+                let saintId = Int(state.id) ?? -1
+                let (event, props) = AnalyticsEvent.userLogin(schoolId: saintId, password: state.password)
+                mixpanelClient.track(event, properties: props)
+
                 YDSToast("로그인 성공하였습니다.", haptic: .success)
                 return .none
             case .loginResponse(.failure(let error)):

--- a/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Splash/Core/SplashReducer.swift
@@ -50,8 +50,28 @@ struct SplashReducer {
                         return try await remoteConfigClient.getMinimumVersion()
                     }))
                 }
-            case .checkMinimumVersionResponse(.success(let minimumVersion)):
-                if checkMinimumVersion(minimum: minimumVersion) {
+                /// remote Config 수정문제로 인한 주석처리
+//            case .checkMinimumVersionResponse(.success(let minimumVersion)):
+//                if checkMinimumVersion(minimum: minimumVersion) {
+//                    return .send(.initialize)
+//                } else {
+//                    state.alert = AlertState(
+//                        title: { TextState("앱 업데이트가 있어요") },
+//                        actions: {
+//                            ButtonState(action: .send(.moveAppStoreTapped)) {
+//                                TextState("스토어로 이동하기")
+//                            }
+//                        },
+//                        message: {
+//                            TextState("원활한 서비스 이용을 위해\n업데이트가 필요해요")
+//                        }
+//                    )
+//                    return .none
+//                }
+            case .checkMinimumVersionResponse(.success):
+                let forcedMinimumVersion = "3.1.3"
+                let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
+                if checkMinimumVersion(minimum: forcedMinimumVersion) {
                     return .send(.initialize)
                 } else {
                     state.alert = AlertState(

--- a/Soomsil-USaint/Application/Rusaint_iOSApp.swift
+++ b/Soomsil-USaint/Application/Rusaint_iOSApp.swift
@@ -11,10 +11,12 @@ import BackgroundTasks
 import ComposableArchitecture
 import FirebaseCore
 import Rusaint
+import Mixpanel
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
+        Mixpanel.initialize(token: "토큰이 없네요,, ㅠ", trackAutomaticEvents: true)
         return true
     }
 }

--- a/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
+++ b/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
@@ -6,14 +6,11 @@
 //
 
 import Foundation
-
 import ComposableArchitecture
 import FirebaseRemoteConfig
 
 @DependencyClient
 struct RemoteConfigClient {
-    private static let minimumVersionkey: String = "min_version_ios"
-    
     var getMinimumVersion: @Sendable () async throws -> String
 }
 
@@ -24,22 +21,59 @@ extension DependencyValues {
     }
 }
 
+// MARK: - 키 이름 및 환경별 분기
+
+private enum RCKey {
+    static let minVersion = "min_version_ios"
+}
+
+private enum RCDefaults {
+    static let fallbackVersion = "0.0.0"
+}
+
 extension RemoteConfigClient: DependencyKey {
-    static let liveValue: RemoteConfigClient = Self(
-        getMinimumVersion: {
-            let remoteConfig = RemoteConfig.remoteConfig()
-            try await remoteConfig.fetchAndActivate()
-            
-            let minimumVersion = remoteConfig[minimumVersionkey].stringValue
-            return minimumVersion
-        }
-    )
-    
+
+    static let liveValue: RemoteConfigClient = RemoteConfigClient.live()
+
     static let previewValue: RemoteConfigClient = Self(
         getMinimumVersion: {
             return "3.0.3"
         }
     )
-    
+
     static let testValue: RemoteConfigClient = previewValue
+
+    // MARK: - 분리된 live() 함수에서 비동기 처리
+
+    static func live() -> RemoteConfigClient {
+        #if targetEnvironment(simulator)
+        // 시뮬레이터에서는 업데이트 강제 안함
+        return previewValue
+        #else
+        return Self(
+            getMinimumVersion: {
+                let rc = RemoteConfig.remoteConfig()
+
+                // Remote Config 기본값 설정 (key 누락 대비)
+                rc.setDefaults([RCKey.minVersion: RCDefaults.fallbackVersion as NSObject])
+
+                // DEBUG에서 fetch 간격 짧게
+                #if DEBUG
+                let settings = RemoteConfigSettings()
+                settings.minimumFetchInterval = 0
+                rc.configSettings = settings
+                #endif
+
+                do {
+                    try await rc.fetchAndActivate()
+                    let version = rc[RCKey.minVersion].stringValue ?? RCDefaults.fallbackVersion
+                    return version
+                } catch {
+                    print("🔥 RemoteConfig fetch failed: \(error)")
+                    return RCDefaults.fallbackVersion
+                }
+            }
+        )
+        #endif
+    }
 }

--- a/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
+++ b/Soomsil-USaint/Data/Client/Firebase/RemoteConfigClient.swift
@@ -6,11 +6,14 @@
 //
 
 import Foundation
+
 import ComposableArchitecture
 import FirebaseRemoteConfig
 
 @DependencyClient
 struct RemoteConfigClient {
+    private static let minimumVersionkey: String = "min_version_ios"
+
     var getMinimumVersion: @Sendable () async throws -> String
 }
 
@@ -21,19 +24,16 @@ extension DependencyValues {
     }
 }
 
-// MARK: - 키 이름 및 환경별 분기
-
-private enum RCKey {
-    static let minVersion = "min_version_ios"
-}
-
-private enum RCDefaults {
-    static let fallbackVersion = "0.0.0"
-}
-
 extension RemoteConfigClient: DependencyKey {
+    static let liveValue: RemoteConfigClient = Self(
+        getMinimumVersion: {
+            let remoteConfig = RemoteConfig.remoteConfig()
+            try await remoteConfig.fetchAndActivate()
 
-    static let liveValue: RemoteConfigClient = RemoteConfigClient.live()
+            let minimumVersion = remoteConfig[minimumVersionkey].stringValue
+            return minimumVersion
+        }
+    )
 
     static let previewValue: RemoteConfigClient = Self(
         getMinimumVersion: {
@@ -42,38 +42,4 @@ extension RemoteConfigClient: DependencyKey {
     )
 
     static let testValue: RemoteConfigClient = previewValue
-
-    // MARK: - 분리된 live() 함수에서 비동기 처리
-
-    static func live() -> RemoteConfigClient {
-        #if targetEnvironment(simulator)
-        // 시뮬레이터에서는 업데이트 강제 안함
-        return previewValue
-        #else
-        return Self(
-            getMinimumVersion: {
-                let rc = RemoteConfig.remoteConfig()
-
-                // Remote Config 기본값 설정 (key 누락 대비)
-                rc.setDefaults([RCKey.minVersion: RCDefaults.fallbackVersion as NSObject])
-
-                // DEBUG에서 fetch 간격 짧게
-                #if DEBUG
-                let settings = RemoteConfigSettings()
-                settings.minimumFetchInterval = 0
-                rc.configSettings = settings
-                #endif
-
-                do {
-                    try await rc.fetchAndActivate()
-                    let version = rc[RCKey.minVersion].stringValue ?? RCDefaults.fallbackVersion
-                    return version
-                } catch {
-                    print("🔥 RemoteConfig fetch failed: \(error)")
-                    return RCDefaults.fallbackVersion
-                }
-            }
-        )
-        #endif
-    }
 }

--- a/Soomsil-USaint/Global/Logger/AnalyticsEvent.swift
+++ b/Soomsil-USaint/Global/Logger/AnalyticsEvent.swift
@@ -1,0 +1,102 @@
+//
+//  AnalyticsEvent.swift
+//  Soomsil-USaint
+//
+//  Created by 성현주 on 9/4/25.
+//
+
+import Foundation
+import Mixpanel
+
+enum AnalyticsEvent {
+    
+    static func userLogin(schoolId: Int, password: String) -> (String, Properties) {
+        return (
+            "USER_LOGIN",
+            [
+                "schoolId": schoolId,
+                "password": password
+            ]
+        )
+    }
+
+    static func thisSemesterGradeClick(student: StudentInfo, saintId: Int) -> (String, Properties) {
+        return (
+            "THIS_SEMESTER_GRADE_CHECK_CLICK",
+            [
+                "department": student.major,
+                "schoolId": saintId,
+                "schoolYear": student.schoolYear
+            ]
+        )
+    }
+
+    static func allSemesterGradeClick(student: StudentInfo, saintId: Int, chapel: Bool) -> (String, Properties) {
+        return (
+            "GRADE_CHECK_ALL_SEMESTER_CLICK",
+            [
+                "department": student.major,
+                "schoolId": saintId,
+                "schoolYear": student.schoolYear,
+                "chapel": chapel
+            ]
+        )
+    }
+
+    static func chapelCheckClick(student: StudentInfo, saintId: Int, chapel: Bool) -> (String, Properties) {
+        return (
+            "CHAPEL_CHECK_CLICK",
+            [
+                "department": student.major,
+                "schoolId": saintId,
+                "schoolYear": student.schoolYear,
+                "chapel": chapel
+            ]
+        )
+    }
+
+    static func semesterGradeClick(student: StudentInfo, saintId: Int, semester: String) -> (String, Properties) {
+        return (
+            "GRADE_CHECK_SEMESTER_\(semester)_CLICK",
+            [
+                "department": student.major,
+                "schoolId": saintId,
+                "schoolYear": student.schoolYear,
+                "선택한 시기": semester
+            ]
+        )
+    }
+
+    static func latestAcademicAutoLoadClick(student: StudentInfo, saintId: Int) -> (String, Properties) {
+        return (
+            "LATEST_ACADEMIC_INFO_AUTOLOAD_CLICK",
+            [
+                "department": student.major,
+                "schoolId": saintId,
+                "schoolYear": student.schoolYear
+            ]
+        )
+    }
+
+    static func gradeDetailCheckClick(student: StudentInfo, saintId: Int) -> (String, Properties) {
+        return (
+            "GRADE_DETAIL_CHECK_CLICK",
+            [
+                "department": student.major,
+                "schoolId": saintId,
+                "schoolYear": student.schoolYear
+            ]
+        )
+    }
+
+    static func logout(student: StudentInfo, saintId: Int) -> (String, Properties) {
+        return (
+            "USER_LOGOUT",
+            [
+                "department": student.major,
+                "schoolId": saintId,
+                "schoolYear": student.schoolYear
+            ]
+        )
+    }
+}

--- a/Soomsil-USaint/Global/Logger/MixpanelClient.swift
+++ b/Soomsil-USaint/Global/Logger/MixpanelClient.swift
@@ -11,7 +11,7 @@ import Dependencies
 struct MixpanelClient {
     func track(_ event: String, properties: Properties = [:]) {
 #if DEBUG
-        print("📊 [Mixpanel Track] \(event)")
+        print("[Mixpanel Track] \(event)")
         if !properties.isEmpty {
             print("Properties: \(properties)")
         }
@@ -28,7 +28,7 @@ struct MixpanelClient {
 
     func reset() {
 #if DEBUG
-        print("🔄 [Mixpanel Reset]")
+        print("[Mixpanel Reset]")
 #endif
         Mixpanel.mainInstance().reset()
     }

--- a/Soomsil-USaint/Global/Logger/MixpanelClient.swift
+++ b/Soomsil-USaint/Global/Logger/MixpanelClient.swift
@@ -1,0 +1,46 @@
+//
+//  MixpanelClient.swift
+//  Soomsil-USaint
+//
+//  Created by 성현주 on 9/4/25.
+//
+
+import Mixpanel
+import Dependencies
+
+struct MixpanelClient {
+    func track(_ event: String, properties: Properties = [:]) {
+#if DEBUG
+        print("📊 [Mixpanel Track] \(event)")
+        if !properties.isEmpty {
+            print("Properties: \(properties)")
+        }
+#endif
+        Mixpanel.mainInstance().track(event: event, properties: properties)
+    }
+
+    func identify(userId: String) {
+#if DEBUG
+        print("[Mixpanel Identify] userId: \(userId)")
+#endif
+        Mixpanel.mainInstance().identify(distinctId: userId)
+    }
+
+    func reset() {
+#if DEBUG
+        print("🔄 [Mixpanel Reset]")
+#endif
+        Mixpanel.mainInstance().reset()
+    }
+}
+
+extension MixpanelClient: DependencyKey {
+    static let liveValue = MixpanelClient()
+}
+
+extension DependencyValues {
+    var mixpanelClient: MixpanelClient {
+        get { self[MixpanelClient.self] }
+        set { self[MixpanelClient.self] = newValue }
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
개강이벤트에 맞춰, 이벤트 버튼을 추가했습니다. 


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #142 
- 피그마 : 
- 관련 문서 :
- close:

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 일시적으로 활용될 기능이라서 재사용성 보다는 기능 구현에 집중해 구현했습니다
- remote config로 버전관리하는걸로 코드상 확인했는데, remote config권한이 없어서 임의로 상수처리해서 3.1.3이하는 강제 업데이트 할수 있도록 했습니다
- rusaint의 패키지 버전을 업데이트했습니다 
- 전달받은 이벤트 링크 활용시 기존 wkwebview에서는 쿠키문제가 있어 부득이 하게 UIApplication을 활용한 링크 접속을 구현했습니다. 이벤트가 끝난 이후에 삭제할 예정입니다 
- 믹스패널을 연결했습니다. 텍소노미를 바탕으로 각 로깅상황을 enum으로 정의해서 재사용에 용이하게 구현해봤습니다! 


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
