### PR TITLE
[#146] 비동기로 채플정보 홈뷰에서 fetch

### DIFF
--- a/Soomsil-USaint.xcodeproj/project.pbxproj
+++ b/Soomsil-USaint.xcodeproj/project.pbxproj
@@ -432,8 +432,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/EATSTEAK/rusaint-ios.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 1.0.0;
+				branch = main;
+				kind = branch;
 			};
 		};
 		7B07475C2E095DDF00A055C7 /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -51,6 +51,7 @@ struct HomeReducer {
         case currentSemesterGradesDismissed
         case semesterGradesPressed
         case getGradeDataResponse(Result<[GradeSummary], Error>)
+        case getChapelDataResponse(Result<ChapelCard, Error>)
         case fetchGradeDataResponse(Result<Void, Error>)
         case fetchCurrentSemesterGradeResponse(Result<[LectureDetail], Error>)
 
@@ -62,6 +63,7 @@ struct HomeReducer {
     @Dependency(\.localNotificationClient) var localNotificationClient
     @Dependency(\.studentClient) var studentClient
     @Dependency(\.gradeClient) var gradeClient
+    @Dependency(\.chapelClient) var chapelClient
     @Dependency(\.mixpanelClient) var mixpanelClient
 
     var body: some Reducer<State, Action> {
@@ -88,6 +90,9 @@ struct HomeReducer {
                 let isFirst = state.isFirst
                 state.$isFirst.withLock { $0 = false }
                 return .run { send in
+                    /// 비동기로 채플 정보 fetch
+                    async let chapelTask = fetchChapelData()
+                    
                     /// 알림 권한 확인
                     await send(.checkPushAuthorizationResponse(Result {
                         if (isFirst) {
@@ -104,6 +109,14 @@ struct HomeReducer {
                         )))
                     } catch {
                         await send(.getGradeDataResponse(.failure(error)))
+                    }
+                    
+                    /// 새로운 fetch한 채플 정보
+                    do {
+                        let chapelResult = try await chapelTask
+                        await send(.getChapelDataResponse(.success(chapelResult)))
+                    } catch {
+                        await send(.getChapelDataResponse(.failure(error)))
                     }
                 }
             case .checkPushAuthorizationResponse(.success(let granted)):
@@ -185,6 +198,15 @@ struct HomeReducer {
                 state.isLoading = false
                 state.toastMessage = String(describing: error)
                 return .none
+            case .getChapelDataResponse(.success(let chapel)):
+                state.chapelCard = chapel
+                return .none
+                
+            case .getChapelDataResponse(.failure(let error)):
+                print(String(describing: error))
+                state.toastMessage = "채플 정보 불러오기 실패"
+                return .none
+                
             case .fetchCurrentSemesterGradeResponse(.success(let lectures)):
                 state.currentSemesterLectures = lectures
                 state.isLoading = false
@@ -209,6 +231,13 @@ struct HomeReducer {
         try await gradeClient.updateTotalReportCard(totalReportCard)
         let allSemesterGrades = try await gradeClient.fetchAllSemesterGrades()
         try await gradeClient.updateAllSemesterGrades(allSemesterGrades)
+    }
+    
+    private func fetchChapelData() async throws -> ChapelCard {
+        try await chapelClient.deleteChapelCard()
+        let chapelCard = try await chapelClient.fetchChapelCard()
+        try await chapelClient.updateChapelCard(chapelCard)
+        return chapelCard
     }
 
     //MARK: - Events

--- a/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/ChapelInfo.swift
@@ -28,7 +28,7 @@ struct ChapelInfo: View {
             
             ZStack {
                 Rectangle()
-                    .frame(width: 350, height: 130)
+                    .frame(height: 130)
                     .cornerRadius(16)
                     .foregroundStyle(.buttonSurface)
                     .shadow(color: .shadow, radius: 7)
@@ -62,7 +62,7 @@ private struct ActiveStatusView: View {
         VStack(spacing: 0) {
             AttendanceView(attendanceCount)
             Divider()
-                .frame(width: 330)
+                .padding(.horizontal, 10)
                 .padding(.vertical, 18)
             SeatPositionView(seatPosition, floorLevel)
             Spacer()
@@ -116,11 +116,13 @@ private struct AttendanceView: View {
                     .fontWeight(.regular)
                     .foregroundStyle(.grayText)
             }
-            .frame(width: 304, height: 23)
+            .frame(height: 23)
+            .padding(.horizontal, 23)
             .padding(.bottom, 5)
             
             ProgressView (value: Double(attendanceCount), total: Double(maxAttendanceCount))
-                .frame(width: 304, height: 6.6)
+                .frame(height: 6.6)
+                .padding(.horizontal, 23)
                 .progressViewStyle(
                     CustomLinearProgressViewStyle(
                         progressColor: .vPrimary,

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -23,16 +23,18 @@ struct HomeView: View {
                     Student(student: store.studentInfo) {
                         store.send(.settingPressed)
                     }
-//                    ReportCardView(reportCard: store.totalReportCard) {
-//                        store.send(.currentSemesterGradesPressed)
-//                    } onSemesterGradesPressed: {
-//                        store.send(.semesterGradesPressed)
-//                    }
                     ReportCardView(reportCard: store.totalReportCard) {
+                        store.send(.currentSemesterGradesPressed)
+                    } onSemesterGradesPressed: {
                         store.send(.semesterGradesPressed)
                     } onGiftLinkPressed: {
                         store.send(.openGiftLinkPressed)
                     }
+//                    ReportCardView(reportCard: store.totalReportCard) {
+//                        store.send(.semesterGradesPressed)
+//                    } onGiftLinkPressed: {
+//                        store.send(.openGiftLinkPressed)
+//                    }
 
 
                     ChapelInfo(chapelCard: ChapelCard(

--- a/Soomsil-USaint/Application/Feature/Home/View/ReportCardView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/ReportCardView.swift
@@ -12,7 +12,7 @@ import YDS_SwiftUI
 struct ReportCardView: View {
     var reportCard: TotalReportCard
     
-    //let onCurrentSemesterPressed: () -> Void
+    let onCurrentSemesterPressed: () -> Void
     let onSemesterGradesPressed: () -> Void
 
     //MARK: - Events
@@ -27,21 +27,27 @@ struct ReportCardView: View {
                 .padding(.bottom, 15)
             
             Button(action: {
-                onGiftLinkPressed()
+                onCurrentSemesterPressed()
+//                onGiftLinkPressed()
             }) {
                 HStack(spacing: 0) {
-                    //Text("이번 학기 성적 확인")
+                    Text("이번 학기 성적 확인")
+                        .foregroundStyle(.titleText)
+                        .font(YDSFont.body1)
+                        .padding(.vertical, 19)
+                    /*
                     Text("🎁 개강 선물 도착, 복권 뽑으러 가기!")
                         .foregroundStyle(.titleText)
                         .font(YDSFont.body1)
                         .padding(.vertical, 19)
-
+                     */
                     Spacer()
                     Image(systemName: "chevron.right")
                         .resizable()
                         .foregroundStyle(.grayText)
                         .frame(width: 10, height: 15)
                         .scaledToFill()
+                     
                 }
                 .padding(.horizontal, 28)
                 .background(.buttonSurface)
@@ -92,7 +98,7 @@ struct CreditLine: View {
 }
 
 #Preview {
-    ReportCardView(reportCard: TotalReportCard(gpa: 4.5, earnedCredit: 123, graduateCredit: 188, generalRank: 10, overallStudentCount: 100)) {} /*onSemesterGradesPressed: {}*/ onGiftLinkPressed: {}
+    ReportCardView(reportCard: TotalReportCard(gpa: 4.5, earnedCredit: 123, graduateCredit: 188, generalRank: 10, overallStudentCount: 100)) {} onSemesterGradesPressed: {} onGiftLinkPressed: {}
         .background(.navigationBarSurface)
         .padding(.horizontal, 20)
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
로그인 이후 최신화되지 않는 채플 정보를 수정했습니다.
앱을 실행 후 홈뷰에 있을 때 1회 채플 정보를 최신화 합니다.
비동기로 `fetchChapelData()`를 수행합니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #146
- 피그마 : 
- 관련 문서 :
- close: 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
rusaint-ios 패키지 버전 요구사항을 수정했습니다.
branch - main으로 변경했습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
테스트는 코어데이터에 최신과 다른 데이터를 넣고 홈뷰에 있을 때 채플 정보가 최신화 되는 것을 시연했습니다.

<img width="743" height="76" alt="스크린샷 2025-09-11 오후 9 47 20" src="https://github.com/user-attachments/assets/44fee803-9b7f-4602-9f20-a008fc83db65" />


https://github.com/user-attachments/assets/fc765859-c047-4da3-91da-196f080c22ac

