### PR TITLE
[#150] 채플 비동기 fetch 재시도 로직

### DIFF
--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -52,6 +52,7 @@ struct HomeReducer {
         case semesterGradesPressed
         case getGradeDataResponse(Result<[GradeSummary], Error>)
         case getChapelDataResponse(Result<ChapelCard, Error>)
+        case fetchChapelDataResponse(Result<ChapelCard, Error>)
         case fetchGradeDataResponse(Result<Void, Error>)
         case fetchCurrentSemesterGradeResponse(Result<[LectureDetail], Error>)
 
@@ -130,8 +131,10 @@ struct HomeReducer {
                     do {
                         let chapelResult = try await chapelTask
                         await send(.getChapelDataResponse(.success(chapelResult)))
+                        debugPrint("채플 정보 업데이트 완료")
                     } catch {
                         await send(.getChapelDataResponse(.failure(error)))
+                        debugPrint("채플 정보 업데이트 실패")
                     }
                 }
 
@@ -214,13 +217,28 @@ struct HomeReducer {
                 state.isLoading = false
                 state.toastMessage = String(describing: error)
                 return .none
+                
             case .getChapelDataResponse(.success(let chapel)):
                 state.chapelCard = chapel
                 return .none
-                
             case .getChapelDataResponse(.failure(let error)):
-                print(String(describing: error))
-                state.toastMessage = "채플 정보 불러오기 실패"
+                debugPrint("첫번째 채플 : \(String(describing: error))")
+                
+                // fetch 재시도
+                return .run { send in
+                    try? await Task.sleep(nanoseconds: 500_000_000)
+                    
+                    await send(.fetchChapelDataResponse(Result {
+                        try await fetchChapelData()
+                    }))
+                }
+                
+            case .fetchChapelDataResponse(.success(let chapel)):
+                state.chapelCard = chapel
+                debugPrint("두번째 채플 fetch 성공")
+                return .none
+            case .fetchChapelDataResponse(.failure(let error)):
+                debugPrint("두번째 채플 fetch 실패 : \(String(describing: error))")
                 return .none
                 
             case .fetchCurrentSemesterGradeResponse(.success(let lectures)):

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -52,7 +52,6 @@ struct HomeReducer {
         case semesterGradesPressed
         case getGradeDataResponse(Result<[GradeSummary], Error>)
         case getChapelDataResponse(Result<ChapelCard, Error>)
-        case fetchChapelDataResponse(Result<ChapelCard, Error>)
         case fetchGradeDataResponse(Result<Void, Error>)
         case fetchCurrentSemesterGradeResponse(Result<[LectureDetail], Error>)
 
@@ -93,7 +92,11 @@ struct HomeReducer {
 
                 return .run { send in
                     // 비동기로 채플 정보 fetch
-                    async let chapelTask = fetchChapelData()
+                    async let chapelTask = retryWithExponentialBackoff(
+                        base: 0.5,
+                        maxInterval: 10,
+                        maxAttempts: 5
+                    ) { try await fetchChapelData() }
 
                     // 먼저 기존 값 보여주기
                     do {
@@ -127,14 +130,12 @@ struct HomeReducer {
                         await send(.getGradeDataResponse(.failure(error)))
                     }
                     
-                    /// 새로운 fetch한 채플 정보
+                    // 지수 백오프로 재시도한 채플 정보 처리
                     do {
                         let chapelResult = try await chapelTask
                         await send(.getChapelDataResponse(.success(chapelResult)))
-                        debugPrint("채플 정보 업데이트 완료")
                     } catch {
                         await send(.getChapelDataResponse(.failure(error)))
-                        debugPrint("채플 정보 업데이트 실패")
                     }
                 }
 
@@ -220,25 +221,10 @@ struct HomeReducer {
                 
             case .getChapelDataResponse(.success(let chapel)):
                 state.chapelCard = chapel
+                NSLog("[채플] 정보 업데이트 완료")
                 return .none
             case .getChapelDataResponse(.failure(let error)):
-                debugPrint("첫번째 채플 : \(String(describing: error))")
-                
-                // fetch 재시도
-                return .run { send in
-                    try? await Task.sleep(nanoseconds: 500_000_000)
-                    
-                    await send(.fetchChapelDataResponse(Result {
-                        try await fetchChapelData()
-                    }))
-                }
-                
-            case .fetchChapelDataResponse(.success(let chapel)):
-                state.chapelCard = chapel
-                debugPrint("두번째 채플 fetch 성공")
-                return .none
-            case .fetchChapelDataResponse(.failure(let error)):
-                debugPrint("두번째 채플 fetch 실패 : \(String(describing: error))")
+                NSLog("[채플] 업데이트 실패: \(String(describing: error))")
                 return .none
                 
             case .fetchCurrentSemesterGradeResponse(.success(let lectures)):
@@ -272,6 +258,41 @@ struct HomeReducer {
         let chapelCard = try await chapelClient.fetchChapelCard()
         try await chapelClient.updateChapelCard(chapelCard)
         return chapelCard
+    }
+    
+    enum ExponentialBackoffError: Error {
+        case retryLimitExceeded
+    }
+    
+    func retryWithExponentialBackoff<Result>(
+        base: Double,
+        maxInterval: Double,
+        maxAttempts: Int,
+        operation: () async throws -> Result
+    ) async throws -> Result {
+        var attempt = 0
+        
+        while attempt < maxAttempts {
+            try Task.checkCancellation()
+            
+            do {
+                NSLog("[채플] 업데이트 시도 \(attempt + 1)")
+                return try await operation()
+            } catch {
+                // 마지막 시도일때 에러 던지기
+                if attempt == maxAttempts - 1 {
+                    throw error
+                }
+            }
+            
+            // 지수백오프 Jitter 적용
+            let sleep = base * Double(pow(Double(2), Double(attempt)))
+            let seconds = Double.random(in: 0...min(maxInterval, sleep))
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            
+            attempt += 1
+        }
+        throw ExponentialBackoffError.retryLimitExceeded
     }
 
     //MARK: - Events

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -95,7 +95,7 @@ struct HomeReducer {
                     async let chapelTask = retryWithExponentialBackoff(
                         base: 0.5,
                         maxInterval: 10,
-                        maxAttempts: 5
+                        maxAttempts: 3
                     ) { try await fetchChapelData() }
 
                     // 먼저 기존 값 보여주기


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
홈리듀서에서 채플 정보를 비동기로 불러오는 첫 시도에 네트워크 에러가 너무 빈번하게 발생해서
1차 fetch 시도 이후 0.5초 대기 후 한번 더 fetch 시도하는 로직을 추가했습니다.

2차 fetch에서까지 실패하는 경우는 거의 없었습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #150 
- 피그마 : 
- 관련 문서 :
- close:

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
debugPrint 내용
```
"첫번째 채플  : networkError(Rusaint.RusaintError.General(message: \"Failed to login with ssu sso: Token is not included in response: 세션에 문제가 있습니다. 다시 로그인해 주세요.\"))"
"채플 정보 업데이트 실패"
"두번째 채플 fetch 성공"
```

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
