### PR TITLE
[#159] v2 메인 화면 리디자인

### DIFF
--- a/Soomsil-USaint/Application/Feature/Component/ChapelAttendanceInfoView.swift
+++ b/Soomsil-USaint/Application/Feature/Component/ChapelAttendanceInfoView.swift
@@ -131,6 +131,10 @@ struct ChapelAttendanceInfoView: View {
         .frame(maxWidth: .infinity)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(.slate100, lineWidth: 1)
+        )
     }
 
     private var attendedBody: some View {
@@ -177,6 +181,10 @@ struct ChapelAttendanceInfoView: View {
         .frame(maxWidth: .infinity)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(.slate100, lineWidth: 1)
+        )
     }
 
     private var completedBody: some View {
@@ -186,6 +194,10 @@ struct ChapelAttendanceInfoView: View {
             .frame(maxWidth: .infinity, minHeight: 80)
             .background(.buttonSurface)
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(.slate100, lineWidth: 1)
+            )
     }
 }
 

--- a/Soomsil-USaint/Application/Feature/Component/CustomTabBar.swift
+++ b/Soomsil-USaint/Application/Feature/Component/CustomTabBar.swift
@@ -50,7 +50,6 @@ struct CustomTabBar: View {
         )
         .padding(.horizontal, 20)
         .padding(.top, 10)
-        .padding(.bottom, 20)
     }
 
     @ViewBuilder

--- a/Soomsil-USaint/Application/Feature/Component/GPAGraphView.swift
+++ b/Soomsil-USaint/Application/Feature/Component/GPAGraphView.swift
@@ -20,7 +20,6 @@ struct GPAGraphView: View {
 
     private let type: GraphType
     private let semesterList: [GradeSummary]
-    private let onDetailTap: (() -> Void)?
 
     @State var isOnSeasonalSemester: Bool = false
 
@@ -28,15 +27,12 @@ struct GPAGraphView: View {
     /// - Parameters:
     ///   - type: 그래프 타입
     ///   - semesterList: 학기별 성적 목록
-    ///   - onDetailTap: 상세 버튼 액션
     init(
         type: GraphType = .line,
-        semesterList: [GradeSummary],
-        onDetailTap: (() -> Void)? = nil
+        semesterList: [GradeSummary]
     ) {
         self.type = type
         self.semesterList = semesterList
-        self.onDetailTap = onDetailTap
     }
 
     // MARK: - Body
@@ -104,6 +100,10 @@ private extension GPAGraphView {
         .padding(.vertical, 20)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(.slate100, lineWidth: 1)
+        )
     }
 
     var barGraphView: some View {
@@ -115,17 +115,12 @@ private extension GPAGraphView {
 
                 Spacer()
 
-                Button {
-                    onDetailTap?()
-                } label: {
-                    HStack(spacing: 4) {
-                        Text(TextLiteral.GPAGraphView.detailButtonTitle)
-                        Image(systemName: "arrow.right")
-                    }
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.blue600)
+                HStack(spacing: 4) {
+                    Text(TextLiteral.GPAGraphView.detailButtonTitle)
+                    Image(systemName: "arrow.right")
                 }
-                .buttonStyle(.plain)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.blue600)
             }
 
             GPABarGraphView(
@@ -136,6 +131,10 @@ private extension GPAGraphView {
         .padding(.vertical, 18)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(.slate100, lineWidth: 1)
+        )
     }
 
     var regularSemesterList: [GradeSummary] {

--- a/Soomsil-USaint/Application/Feature/Component/ReportCardView.swift
+++ b/Soomsil-USaint/Application/Feature/Component/ReportCardView.swift
@@ -20,24 +20,20 @@ struct ReportCardView: View {
     private let type: ViewType
     private let reportCard: TotalReportCard
     private let lectureCount: Int?
-    private let onCurrentSemesterPressed: (() -> Void)?
 
     /// 성적 카드 구성
     /// - Parameters:
     ///   - type: 카드 표시 타입 (overview, summary중 택 1)
     ///   - reportCard: 전체 성적 모델
     ///   - lectureCount: 과목 수
-    ///   - onCurrentSemesterPressed: 이번 학기 성적 액션
     init(
         type: ViewType = .overview,
         reportCard: TotalReportCard,
-        lectureCount: Int? = nil,
-        onCurrentSemesterPressed: (() -> Void)? = nil
+        lectureCount: Int? = nil
     ) {
         self.type = type
         self.reportCard = reportCard
         self.lectureCount = lectureCount
-        self.onCurrentSemesterPressed = onCurrentSemesterPressed
     }
 
     // MARK: - Body
@@ -78,22 +74,17 @@ private extension ReportCardView {
                     .foregroundStyle(.white.opacity(0.5))
             }
 
-            Button {
-                onCurrentSemesterPressed?()
-            } label: {
-                HStack(spacing: 6) {
-                    Text(TextLiteral.ReportCardView.currentSemesterButtonTitle)
-                    Image(systemName: "arrow.right")
-                        .frame(width: 14, height: 14)
-                }
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.gray950)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .background(.white)
-                .clipShape(Capsule())
+            HStack(spacing: 6) {
+                Text(TextLiteral.ReportCardView.currentSemesterButtonTitle)
+                Image(systemName: "arrow.right")
+                    .frame(width: 14, height: 14)
             }
-            .buttonStyle(.plain)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(.gray950)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(.white)
+            .clipShape(Capsule())
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 24)
@@ -182,7 +173,7 @@ private extension ReportCardView {
                     generalRank: 12,
                     overallStudentCount: 100
                 ),
-                onCurrentSemesterPressed: {}
+                lectureCount: nil
             )
 
             ReportCardView(

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -48,14 +48,11 @@ struct HomeReducer {
         case currentSemesterGradesPressed
         case currentSemesterGradesDismissed
         case semesterGradesPressed
+        case chapelAttendancePressed
         case getGradeDataResponse(Result<[GradeSummary], Error>)
         case getChapelDataResponse(Result<ChapelCard, Error>)
         case fetchGradeDataResponse(Result<Void, Error>)
         case fetchCurrentSemesterGradeResponse(Result<[LectureDetail], Error>)
-
-        //MARK: - Events
-
-        case openGiftLinkPressed
     }
     
     @Dependency(\.localNotificationClient) var localNotificationClient
@@ -174,6 +171,18 @@ struct HomeReducer {
                 mixpanelClient.track(event, properties: props)
                 state.path.append(.semesterDetail(SemesterDetailReducer.State()))
                 return .none
+            case .chapelAttendancePressed:
+                let student = state.studentInfo
+                let saintId = Int(StudentClient.keychain["saintID"] ?? "") ?? -1
+                let chapel = state.chapelCard.status == .active
+
+                let (event, props) = AnalyticsEvent.chapelCheckClick(
+                    student: student,
+                    saintId: saintId,
+                    chapel: chapel
+                )
+                mixpanelClient.track(event, properties: props)
+                return .none
             case .getGradeDataResponse(.success(let semesterList)):
                 if(semesterList.isEmpty) {
                     return .run { send in
@@ -217,8 +226,6 @@ struct HomeReducer {
                 state.toastMessage = String(describing: error)
                 state.isLoading = false
                 return .none
-            case .openGiftLinkPressed:
-                return handleGiftLinkPressed(&state)
             default:
                 return .none
             }
@@ -275,33 +282,6 @@ struct HomeReducer {
             attempt += 1
         }
         throw ExponentialBackoffError.retryLimitExceeded
-    }
-
-    //MARK: - Events
-
-    private func handleGiftLinkPressed(_ state: inout State) -> Effect<Action> {
-        let student = state.studentInfo
-
-        guard let saintID = StudentClient.keychain["saintID"] else {
-            state.toastMessage = "학번을 불러올 수 없습니다."
-            return .none
-        }
-
-        let baseURL = "https://lottery-one.vercel.app"
-
-        let major = student.major.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        let name = student.name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        let schoolNumber = saintID.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-
-        let fullURLString = "\(baseURL)?major=\(major)&name=\(name)&schoolNumber=\(schoolNumber)"
-
-        guard let url = URL(string: fullURLString) else {
-            state.toastMessage = "복권 페이지 링크를 열 수 없습니다."
-            return .none
-        }
-
-        state.path.append(.web(WebReducer.State(url: url)))
-        return .none
     }
 
 }

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 import ComposableArchitecture
-import YDS_SwiftUI
 
 struct HomeView: View {
     @Bindable var store: StoreOf<HomeReducer>
@@ -17,43 +16,46 @@ struct HomeView: View {
         NavigationStack(
             path: $store.scope(state: \.path, action: \.path)
         ){
-            VStack {
-                title
-                VStack(alignment: .leading, spacing: 0) {
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 16) {
+                    header
+
                     StudentInfoView(student: store.studentInfo)
-                    ReportCardView(
-                        type: .overview,
-                        reportCard: store.totalReportCard,
-                        onCurrentSemesterPressed: {
-                            store.send(.currentSemesterGradesPressed)
-                        }
-                    )
-                    .padding(.horizontal, 20)
-                    .padding(.top, 24)
 
                     Button {
-                        store.send(.semesterGradesPressed)
+                        store.send(.currentSemesterGradesPressed)
                     } label: {
                         ReportCardView(
-                            type: .summary,
+                            type: .overview,
                             reportCard: store.totalReportCard
                         )
                     }
                     .buttonStyle(.plain)
-                    .padding(.horizontal, 20)
-                    .padding(.top, 16)
 
-                    ChapelAttendanceInfoView(
-                        type: .attended,
-                        chapelCard: store.chapelCard
-                    )
-                    .padding(.horizontal, 20)
-                    .padding(.top, 24)
-                    
-                    Spacer()
+                    Button {
+                        store.send(.semesterGradesPressed)
+                    } label: {
+                        GPAGraphView(
+                            type: .bar,
+                            semesterList: store.semesterList
+                        )
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        store.send(.chapelAttendancePressed)
+                    } label: {
+                        ChapelAttendanceInfoView(
+                            type: .attended,
+                            chapelCard: store.chapelCard
+                        )
+                    }
+                    .buttonStyle(.plain)
                 }
+                .padding(.horizontal, 20)
+                .padding(.bottom, 110)
             }
-            .background(.backgroundSurface)
+            .background(.white)
         } destination: { store in
             switch store.case {
             case .semesterList(let store):
@@ -89,16 +91,17 @@ struct HomeView: View {
 }
 
 private extension HomeView {
-    var title: some View {
-        HStack {
-            Text("유세인트")
-                .font(YDSFont.title2)
-                .padding(.horizontal, 20)
-                .padding(.bottom, 10)
-            Spacer()
+    var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(TextLiteral.HomeView.greeting(store.studentInfo.name))
+                .font(.system(size: 20, weight: .bold))
+                .foregroundStyle(.gray850)
+                .lineLimit(1)
+
+            Text(TextLiteral.HomeView.notificationSummary(count: 0))
+                .font(.system(size: 12, weight: .regular))
+                .foregroundStyle(.gray500)
         }
-        .frame(maxWidth: .infinity)
-        .background(.navigationBarSurface)
     }
 }
 

--- a/Soomsil-USaint/Application/Feature/Home/View/StudentInfoView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/StudentInfoView.swift
@@ -42,6 +42,10 @@ struct StudentInfoView: View {
         .frame(maxWidth: .infinity)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(.slate100, lineWidth: 1)
+        )
         .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 }

--- a/Soomsil-USaint/Application/Feature/MainTab/Core/MainTabReducer.swift
+++ b/Soomsil-USaint/Application/Feature/MainTab/Core/MainTabReducer.swift
@@ -36,6 +36,9 @@ struct MainTabReducer {
             case .tabSelected(let tab):
                 state.selectedTab = tab
                 return .none
+            case .home(.chapelAttendancePressed):
+                state.selectedTab = .chapel
+                return .none
             default:
                 return .none
             }

--- a/Soomsil-USaint/Global/Utils/TextLiteral.swift
+++ b/Soomsil-USaint/Global/Utils/TextLiteral.swift
@@ -8,6 +8,22 @@
 import Foundation
 
 enum TextLiteral {
+    // MARK: - HomeView
+
+    enum HomeView {
+        /// 인사 문구 생성
+        /// - Parameter name: 학생 이름
+        static func greeting(_ name: String) -> String {
+            "안녕하세요, \(name)님"
+        }
+
+        /// 알림 요약 문구 생성
+        /// - Parameter count: 알림 개수
+        static func notificationSummary(count: Int) -> String {
+            "이번 주 확인할 알림 \(count)개"
+        }
+    }
+
     // MARK: - GPAGraphView
 
     enum GPAGraphView {


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- [x] 메인 화면 리디자인
- [x] 내 성적 컴포넌트 클릭 시 -> 이번 학기 성적 모달 등장
- [x] 전체 학기 추이 컴포넌트 클릭 시 -> 성적 상세 보기 화면 이동
- [x] 채플 출석 컴포넌트 클릭 시 -> 메인 탭바 2번째 탭으로 이동


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #159 
- 피그마 : 
- 관련 문서 :
- close: #159 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->

 ### 홈 화면 리디자인

  - 홈 화면을 v2 디자인 기준으로 재구성했습니다.
  - StudentInfoView, ReportCardView, GPAGraphView, ChapelAttendanceInfoView를 조합해 메인
    화면을 구성했습니다.
  - 기존 홈 화면의 불필요한 레이아웃과 사용하지 않는 네비게이션 코드를 정리했습니다.
  - 홈 화면 상단에 사용자 인사말과 이번 주 알림 개수를 표시하도록 구성했습니다.

  ### 홈 화면 액션 연결

  - 내 성적 컴포넌트 클릭 시 이번 학기 성적 모달이 표시되도록 연결했습니다.
  - 전체 학기 추이 컴포넌트 클릭 시 성적 상세 화면으로 이동하도록 연결했습니다.
  - 채플 출석 컴포넌트 클릭 시 메인 탭의 채플 탭으로 이동하도록 연결했습니다.
  - 공통 컴포넌트 내부에는 직접적인 tap handler를 두지 않고, 상위 뷰에서 Button으로 액션을
    주입하도록 정리했습니다.

  ### Reducer 역할 정리

  - HomeReducer는 홈 화면 내부 상태, 홈 화면 네비게이션, 성적 모달 표시, 데이터 fetch 흐름
    을 담당하도록 유지했습니다.
  - MainTabReducer는 메인 탭 선택 상태를 관리하고, 홈에서 발생한 채플 이동 액션을 받아 2번
    째 탭으로 전환하도록 구성했습니다.
  - HomeView는 홈 화면 컴포넌트 조합과 사용자 액션 전달을 담당하도록 정리했습니다.
  - MainTabView는 탭 구조와 탭 선택 바인딩을 담당하도록 정리했습니다.

  ### 컴포넌트 스타일 보정

  - StudentInfoView, ChapelAttendanceInfoView, GPAGraphView에 slate100, lineWidth: 1 stroke
    를 추가해 디자인 기준에 맞췄습니다.
  - 카드형 컴포넌트들의 corner radius, padding, spacing을 v2 디자인에 맞게 정리했습니다.

  ### StudentInfoView

  - 학생 정보를 별도 컴포넌트로 분리했습니다.
  - 이름, 학과, 학년, 재학 상태를 표시하도록 구성했습니다.
  - 학번은 optional로 처리해 값이 있을 때만 badge가 표시되도록 했습니다.

  ### ChapelAttendanceInfoView

  - 채플 출석 컴포넌트를 공통 컴포넌트로 분리했습니다.
  - 이번 학기 출석, 채플 출석 타입을 하나의 컴포넌트 안에서 분기하도록 구성했습니다.
  - 채플 수료 완료 상태는 진행바 없이 텍스트만 표시하도록 정리했습니다.

  ### GPAGraphView

  - GPA 그래프 컴포넌트를 공통 컴포넌트로 이동했습니다.
  - GraphType을 통해 라인 그래프와 막대 그래프를 구분하도록 구성했습니다.
  - 라인 그래프와 막대 그래프 구현을 각각 별도 파일로 분리해 GPAGraphView의 책임을 줄였습니
    다.
  - 막대 그래프는 입력 데이터 개수만큼 표시되며, 부모 너비를 채우되 막대 최대 너비는 52로
    제한했습니다.

  ### ReportCardView

  - 기존 성적 정보 컴포넌트를 v2 디자인 기준의 ReportCardView로 통합했습니다.
  - overview, summary 타입을 통해 홈 화면용 큰 카드와 요약 카드 형태를 구분했습니다.
  - 클릭 액션은 컴포넌트 내부가 아닌 사용하는 상위 뷰에서 처리하도록 변경했습니다.

  ### GradeRowView

  - 성적 row 컴포넌트를 공통 컴포넌트로 이동했습니다.
  - 기존 중복된 GradeRow, GradeRowView 역할을 정리했습니다.
  - compact, detailed 타입을 통해 현재 학기 성적 모달과 성적 상세 화면에서 같은 컴포넌트를
    재사용하도록 구성했습니다.

  ### TextLiteral 정리

  - 홈 화면, 메인 탭, 학생 정보, 채플 출석, GPA 그래프, 성적 카드, 성적 row에서 사용하는 주
    요 텍스트 리터럴을 TextLiteral로 분리했습니다.
  - Preview용 샘플 텍스트는 기존처럼 직접 확인하기 쉽도록 유지했습니다.

  ### Dead Code 제거

  - 더 이상 사용하지 않는 openGiftLinkPressed 액션을 제거했습니다.
  - handleGiftLinkPressed와 lottery-one.vercel.app 링크 처리 코드를 삭제했습니다.
  - rg로 남은 참조가 없는 것을 확인했습니다.


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

| 기존 화면 | 리디자인 화면 |
|---|---|
| <img width="286" height="604" alt="기존 화면" src="https://github.com/user-attachments/assets/45b4def2-68dc-431f-b392-20f84ac2017d" /> | <img width="224" height="489" alt="리디자인 화면" src="https://github.com/user-attachments/assets/c9a8626b-cfd4-4884-8597-01c8d3e4f3ef" /> |

## 🔥 Test
<!-- Test -->

https://github.com/user-attachments/assets/9b42abba-25c4-4818-a365-3af102a1158c

