### PR TITLE
[#161] v2 채플 정보 리디자인

### DIFF
--- a/Soomsil-USaint/Application/AppReducer.swift
+++ b/Soomsil-USaint/Application/AppReducer.swift
@@ -17,7 +17,7 @@ struct AppReducer {
     enum State {
         case initial(SplashReducer.State)
         case loggedOut(LoginReducer.State)
-        case loggedIn(HomeReducer.State)
+        case loggedIn(MainTabReducer.State)
         
         init() {
             self = .initial(SplashReducer.State())
@@ -28,7 +28,7 @@ struct AppReducer {
         case backgroundTask
         case splash(SplashReducer.Action)
         case login(LoginReducer.Action)
-        case home(HomeReducer.Action)
+        case mainTab(MainTabReducer.Action)
     }
     
     @Dependency(\.gradeClient) var gradeClient
@@ -43,13 +43,13 @@ struct AppReducer {
                     try await scheduleChangedGardeLecturePush()
                 }
             case .splash(.initResponse(.success(let (studentInfo, totalReportCard, chapelCard)))):
-                state = .loggedIn(HomeReducer.State(studentInfo: studentInfo, totalReportCard: totalReportCard, chapelCard: chapelCard))
+                state = .loggedIn(MainTabReducer.State(studentInfo: studentInfo, totalReportCard: totalReportCard, chapelCard: chapelCard))
                 return .none
             case .splash(.initResponse(.failure)):
                 state = .loggedOut(LoginReducer.State())
                 return .none
             case .login(.loginResponse(.success(let (info, report, chapel)))):
-                state = .loggedIn(HomeReducer.State(studentInfo: info, totalReportCard: report, chapelCard: chapel))
+                state = .loggedIn(MainTabReducer.State(studentInfo: info, totalReportCard: report, chapelCard: chapel))
                 return .none
             default:
                 return .none
@@ -61,8 +61,8 @@ struct AppReducer {
         .ifCaseLet(\.loggedOut, action: \.login) {
             LoginReducer()
         }
-        .ifCaseLet(\.loggedIn, action: \.home) {
-            HomeReducer()
+        .ifCaseLet(\.loggedIn, action: \.mainTab) {
+            MainTabReducer()
         }
     }
     

--- a/Soomsil-USaint/Application/AppView.swift
+++ b/Soomsil-USaint/Application/AppView.swift
@@ -23,8 +23,8 @@ struct AppView: View {
                 LoginView(store: store)
             }
         case .loggedIn:
-            if let store = store.scope(state: \.loggedIn, action: \.home) {
-                HomeView(store: store)
+            if let store = store.scope(state: \.loggedIn, action: \.mainTab) {
+                MainTabView(store: store)
             }
         }
     }

--- a/Soomsil-USaint/Application/Feature/Chapel/View/ChapelView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/View/ChapelView.swift
@@ -1,0 +1,120 @@
+//
+//  ChapelView.swift
+//  Soomsil-USaint
+//
+//  Created by 정민지 on 5/6/26.
+//
+
+import SwiftUI
+
+/// 채플 탭 화면
+struct ChapelView: View {
+    // MARK: - Properties
+
+    private let chapelCard: ChapelCard
+
+    /// 채플 화면 구성
+    /// - Parameter chapelCard: 채플 정보 모델
+    init(chapelCard: ChapelCard) {
+        self.chapelCard = chapelCard
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            headerView
+
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 12) {
+                    ChapelSeatInfoView(
+                        type: .actionCard,
+                        chapelCard: chapelCard
+                    )
+
+                    ChapelAttendanceInfoView(
+                        type: .semester,
+                        chapelCard: chapelCard,
+                        titleText: TextLiteral.ChapelView.remainingAttendanceTitle
+                    )
+                }
+                .padding(.horizontal, 29)
+                .padding(.vertical, 8)
+            }
+
+            Spacer(minLength: 0)
+
+            attendanceArea
+        }
+        .background(.white)
+    }
+}
+
+// MARK: - View
+
+private extension ChapelView {
+    var headerView: some View {
+        HStack(alignment: .center) {
+            Text(TextLiteral.ChapelView.title)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.gray950)
+
+            Spacer()
+
+            Button {
+                // TODO: 채플 안내 화면 연결
+            } label: {
+                Icon.info
+                    .renderingMode(.template)
+                    .foregroundStyle(.gray500)
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(TextLiteral.ChapelView.title)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+    }
+
+    var attendanceArea: some View {
+        VStack(spacing: 8) {
+            Button {
+                // TODO: 출석 인증 QR 스캔 연결
+            } label: {
+                HStack(spacing: 8) {
+                    Icon.qr
+                        .renderingMode(.template)
+                        .foregroundStyle(.white)
+                        .frame(width: 18, height: 18)
+
+                    Text(TextLiteral.ChapelView.attendanceButtonTitle)
+                        .font(.system(size: 16, weight: .bold))
+                }
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 18)
+                .background(.gray950)
+                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+            .buttonStyle(.plain)
+
+            Text(TextLiteral.ChapelView.attendanceGuide)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.gray500)
+        }
+        .padding(.horizontal, 20)
+        .padding(.bottom, 32)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ChapelView(
+        chapelCard: ChapelCard(
+            attendance: 3,
+            seatPosition: "B-12",
+            floorLevel: 1
+        )
+    )
+}

--- a/Soomsil-USaint/Application/Feature/Chapel/View/ChapelView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/View/ChapelView.swift
@@ -27,10 +27,12 @@ struct ChapelView: View {
 
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 12) {
-                    ChapelSeatInfoView(
-                        type: .actionCard,
-                        chapelCard: chapelCard
-                    )
+                    if chapelCard.status.isActive {
+                        ChapelSeatInfoView(
+                            type: .actionCard,
+                            chapelCard: chapelCard
+                        )
+                    }
 
                     ChapelAttendanceInfoView(
                         type: .semester,

--- a/Soomsil-USaint/Application/Feature/MainTab/View/MainTabView.swift
+++ b/Soomsil-USaint/Application/Feature/MainTab/View/MainTabView.swift
@@ -28,7 +28,7 @@ struct MainTabView: View {
         case .home:
             HomeView(store: store.scope(state: \.homeState, action: \.home))
         case .chapel:
-            placeholderView(TextLiteral.MainTabView.chapelPlaceholder)
+            ChapelView(chapelCard: store.homeState.chapelCard)
         case .notification:
             placeholderView(TextLiteral.MainTabView.notificationPlaceholder)
         case .my:

--- a/Soomsil-USaint/Global/Utils/TextLiteral.swift
+++ b/Soomsil-USaint/Global/Utils/TextLiteral.swift
@@ -170,6 +170,15 @@ enum TextLiteral {
         }
     }
 
+    // MARK: - ChapelView
+
+    enum ChapelView {
+        static let title = "채플"
+        static let remainingAttendanceTitle = "이번 학기 남은 출석"
+        static let attendanceButtonTitle = "출석 인증하기"
+        static let attendanceGuide = "입실 후 좌석 QR을 스캔해주세요"
+    }
+
     // MARK: - MainTabView
 
     enum MainTabView {


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->

- [x] v2 채플 정보 리디자인

추후 해야할 일
- [ ] info 버튼 연결
- [ ] 출석 QR 인증 기능 구현
- [ ] 내 자리 확인 페이지 연결
- [x] 채플 수료 완료 시 UI처리

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #162 
- 피그마 : 
- 관련 문서 :
- close: #162 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->

### 메인 진입 경로 변경

  - 로그인 성공 후 기존 HomeView로 직접 진입하던 구조를 MainTabView 진입 구조로 변경했습니
    다.
  - 스플래시 자동 로그인 성공 시에도 동일하게 MainTabView 상태로 진입하도록 맞췄습니다.
  - AppReducer의 로그인 완료 상태를 HomeReducer.State 기반에서 MainTabReducer.State 기반으
    로 변경했습니다.
  - AppView에서 .loggedIn 상태일 때 HomeView가 아닌 MainTabView를 렌더링하도록 수정했습니
    다.

  ### 채플 화면 구현

  - 채플 탭에서 사용할 ChapelView를 새로 구현했습니다.
  - 채플 화면 구성 요소를 디자인 기준에 맞춰 배치했습니다.
      - 상단 타이틀 영역
      - 정보 아이콘 버튼
      - 내 자리 카드
      - 이번 학기 남은 출석 카드
      - 출석 인증 버튼
      - QR 스캔 안내 문구
  - 출석 인증 안내 문구에 밑줄 스타일을 적용했습니다.
  - 정보 아이콘 색상 변경이 가능하도록 템플릿 렌더링 방식 적용을 반영했습니다.

  ### 메인 탭바 연결

  - MainTabView의 채플 탭 placeholder를 실제 ChapelView로 교체했습니다.
  - 홈 화면의 채플 출석 컴포넌트 클릭 시 메인 탭바의 두 번째 탭으로 이동하는 기존 흐름과 연
    결되도록 유지했습니다.
  - 현재 채플 화면은 표시 중심 View로 구성했고, 별도 액션이 필요한 기능은 추후
    ChapelReducer로 분리할 수 있도록 구조를 열어두었습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

<img width="238" height="516" alt="Image" src="https://github.com/user-attachments/assets/fd6150e1-436f-4582-8a5f-efc5060957e7" />

## 🔥 Test
<!-- Test -->

https://github.com/user-attachments/assets/36665357-a95d-4521-8c09-89f2fbf1c88c

<채플 수료 완료시>
<img width="413" height="853" alt="스크린샷 2026-05-12 오전 9 40 42" src="https://github.com/user-attachments/assets/a702f443-127f-458a-afcc-dca4f30b9345" />
