### PR TITLE
[#163] ChapelSeatLocationView 구현

### DIFF
--- a/Soomsil-USaint/Application/Feature/Chapel/Chapel/Core/ChapelReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/Chapel/Core/ChapelReducer.swift
@@ -1,0 +1,62 @@
+//
+//  ChapelReducer.swift
+//  Soomsil-USaint
+//
+//  Created by 정민지 on 5/12/26.
+//
+
+import Foundation
+
+import ComposableArchitecture
+
+@Reducer
+struct ChapelReducer {
+    @Reducer
+    enum Path {
+        case seatLocation(ChapelSeatLocationReducer)
+    }
+
+    @ObservableState
+    struct State {
+        var chapelCard: ChapelCard
+        var path = StackState<Path.State>()
+
+        init(chapelCard: ChapelCard) {
+            self.chapelCard = chapelCard
+        }
+
+        mutating func updateChapelCard(_ chapelCard: ChapelCard) {
+            self.chapelCard = chapelCard
+        }
+    }
+
+    enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        case path(StackActionOf<Path>)
+        case infoButtonTapped
+        case seatCardTapped
+        case attendanceButtonTapped
+    }
+
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .binding:
+                return .none
+            case .path:
+                return .none
+            case .infoButtonTapped:
+                // TODO: 채플 안내 화면 연결
+                return .none
+            case .seatCardTapped:
+                state.path.append(.seatLocation(ChapelSeatLocationReducer.State(chapelCard: state.chapelCard)))
+                return .none
+            case .attendanceButtonTapped:
+                // TODO: 출석 인증 QR 스캔 연결
+                return .none
+            }
+        }
+        .forEach(\.path, action: \.path)
+    }
+}

--- a/Soomsil-USaint/Application/Feature/Chapel/Chapel/View/ChapelView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/Chapel/View/ChapelView.swift
@@ -7,48 +7,59 @@
 
 import SwiftUI
 
+import ComposableArchitecture
+
 /// 채플 탭 화면
 struct ChapelView: View {
     // MARK: - Properties
 
-    private let chapelCard: ChapelCard
-
-    /// 채플 화면 구성
-    /// - Parameter chapelCard: 채플 정보 모델
-    init(chapelCard: ChapelCard) {
-        self.chapelCard = chapelCard
-    }
+    @Bindable var store: StoreOf<ChapelReducer>
 
     // MARK: - Body
 
     var body: some View {
-        VStack(spacing: 0) {
-            headerView
+        NavigationStack(
+            path: $store.scope(state: \.path, action: \.path)
+        ) {
+            VStack(spacing: 0) {
+                headerView
 
-            ScrollView(showsIndicators: false) {
-                VStack(spacing: 12) {
-                    if chapelCard.status.isActive {
-                        ChapelSeatInfoView(
-                            type: .actionCard,
-                            chapelCard: chapelCard
+                ScrollView(showsIndicators: false) {
+                    VStack(spacing: 12) {
+                        if store.chapelCard.status.isActive {
+                            Button {
+                                store.send(.seatCardTapped)
+                            } label: {
+                                ChapelSeatInfoView(
+                                    type: .actionCard,
+                                    chapelCard: store.chapelCard
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+
+                        ChapelAttendanceInfoView(
+                            type: .semester,
+                            chapelCard: store.chapelCard,
+                            titleText: TextLiteral.ChapelView.remainingAttendanceTitle
                         )
                     }
-
-                    ChapelAttendanceInfoView(
-                        type: .semester,
-                        chapelCard: chapelCard,
-                        titleText: TextLiteral.ChapelView.remainingAttendanceTitle
-                    )
+                    .padding(.horizontal, 29)
+                    .padding(.vertical, 8)
                 }
-                .padding(.horizontal, 29)
-                .padding(.vertical, 8)
+
+                Spacer(minLength: 0)
+
+                attendanceArea
             }
-
-            Spacer(minLength: 0)
-
-            attendanceArea
+            .background(.white)
+            .toolbar(.hidden, for: .navigationBar)
+        } destination: { store in
+            switch store.case {
+            case .seatLocation(let store):
+                ChapelSeatLocationView(store: store)
+            }
         }
-        .background(.white)
     }
 }
 
@@ -64,7 +75,7 @@ private extension ChapelView {
             Spacer()
 
             Button {
-                // TODO: 채플 안내 화면 연결
+                store.send(.infoButtonTapped)
             } label: {
                 Icon.info
                     .renderingMode(.template)
@@ -81,7 +92,7 @@ private extension ChapelView {
     var attendanceArea: some View {
         VStack(spacing: 8) {
             Button {
-                // TODO: 출석 인증 QR 스캔 연결
+                store.send(.attendanceButtonTapped)
             } label: {
                 HStack(spacing: 8) {
                     Icon.qr
@@ -113,10 +124,16 @@ private extension ChapelView {
 
 #Preview {
     ChapelView(
-        chapelCard: ChapelCard(
-            attendance: 3,
-            seatPosition: "B-12",
-            floorLevel: 1
-        )
+        store: Store(
+            initialState: ChapelReducer.State(
+                chapelCard: ChapelCard(
+                    attendance: 3,
+                    seatPosition: "B-12",
+                    floorLevel: 1
+                )
+            )
+        ) {
+            ChapelReducer()
+        }
     )
 }

--- a/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/Core/ChapelSeatLocationReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/Core/ChapelSeatLocationReducer.swift
@@ -1,0 +1,43 @@
+//
+//  ChapelSeatLocationReducer.swift
+//  Soomsil-USaint
+//
+//  Created by 정민지 on 5/12/26.
+//
+
+import Foundation
+
+import ComposableArchitecture
+
+@Reducer
+struct ChapelSeatLocationReducer {
+    @ObservableState
+    struct State {
+        var chapelCard: ChapelCard
+
+        var seatLocation: ChapelSeatLocation {
+            ChapelSeatLocation(seatPosition: chapelCard.seatPosition)
+        }
+    }
+
+    enum Action {
+        case backButtonTapped
+        case infoButtonTapped
+    }
+
+    @Dependency(\.dismiss) var dismiss
+
+    var body: some ReducerOf<Self> {
+        Reduce { _, action in
+            switch action {
+            case .backButtonTapped:
+                return .run { _ in
+                    await dismiss()
+                }
+            case .infoButtonTapped:
+                // TODO: 채플 좌석 안내 화면 연결
+                return .none
+            }
+        }
+    }
+}

--- a/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/Model/ChapelSeatMapData.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/Model/ChapelSeatMapData.swift
@@ -1,0 +1,305 @@
+//
+//  ChapelSeatMapData.swift
+//  Soomsil-USaint
+//
+//  Created by 정민지 on 5/12/26.
+//
+
+import Foundation
+
+extension ChapelSeatZone {
+    static func definition(for id: String) -> ChapelSeatZone? {
+        all.first { $0.id == id }
+    }
+
+    static let all: [ChapelSeatZone] = [
+        .a,
+        .b,
+        .c,
+        .d,
+        .e,
+        .f,
+        .g,
+        .h,
+        .i,
+        .j
+    ]
+
+    private static func zone(
+        id: String,
+        pattern: [String],
+        entranceDirection: ChapelSeatEntranceDirection
+    ) -> ChapelSeatZone {
+        var rows: [ChapelSeatRow] = []
+        var aisleAfterRows = Set<Int>()
+        let columns = pattern
+            .filter { $0 != "gap" }
+            .map(\.count)
+            .max() ?? 0
+
+        for item in pattern {
+            if item == "gap" {
+                aisleAfterRows.insert(rows.count)
+                continue
+            }
+
+            var seatNumber = 0
+            let seats = item.map { character -> Int? in
+                guard character == "1" else {
+                    return nil
+                }
+
+                seatNumber += 1
+                return seatNumber
+            }
+
+            rows.append(ChapelSeatRow(seats: seats))
+        }
+
+        return ChapelSeatZone(
+            id: id,
+            columns: columns,
+            rows: rows,
+            aisleAfterRows: aisleAfterRows,
+            entranceDirection: entranceDirection
+        )
+    }
+
+    static let a = zone(
+        id: "A",
+        pattern: [
+            "00011111",
+            "00111111",
+            "01111111",
+            "11111111",
+            "11111111",
+            "11111111",
+            "01111111",
+            "gap",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111100"
+        ],
+        entranceDirection: .left
+    )
+
+    static let b = zone(
+        id: "B",
+        pattern: [
+            "0111111",
+            "0111111",
+            "0111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "gap",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1110000"
+        ],
+        entranceDirection: .left
+    )
+
+    static let c = zone(
+        id: "C",
+        pattern: [
+            "111111111",
+            "1111111111",
+            "1111111111",
+            "1111111111",
+            "1111111111",
+            "11111111111",
+            "11111111111",
+            "gap",
+            "11111111111",
+            "11111111111",
+            "11111111111",
+            "11111111111",
+            "11111111111",
+            "11111111111",
+            "11111111111",
+            "11111111111"
+        ],
+        entranceDirection: .left
+    )
+
+    static let d = zone(
+        id: "D",
+        pattern: [
+            "1111100",
+            "1111110",
+            "1111110",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "gap",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111"
+        ],
+        entranceDirection: .right
+    )
+
+    static let e = zone(
+        id: "E",
+        pattern: [
+            "11111000",
+            "11111100",
+            "11111110",
+            "11111111",
+            "11111111",
+            "11111111",
+            "11111110",
+            "gap",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "0011111"
+        ],
+        entranceDirection: .right
+    )
+
+    static let f = zone(
+        id: "F",
+        pattern: [
+            "11111111",
+            "11111111",
+            "11111111",
+            "11111111",
+            "11111111",
+            "11111111",
+            "gap",
+            "11100000",
+            "11100000",
+            "11100000",
+            "11100000",
+            "11111111",
+            "11111111",
+            "11111111",
+            "00111111",
+            "00111110"
+        ],
+        entranceDirection: .left
+    )
+
+    static let g = zone(
+        id: "G",
+        pattern: [
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "gap",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111110",
+            "1111110"
+        ],
+        entranceDirection: .left
+    )
+
+    static let h = zone(
+        id: "H",
+        pattern: [
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111",
+            "gap",
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111",
+            "111111111"
+        ],
+        entranceDirection: .left
+    )
+
+    static let i = zone(
+        id: "I",
+        pattern: [
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "gap",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111",
+            "1111111"
+        ],
+        entranceDirection: .right
+    )
+
+    static let j = zone(
+        id: "J",
+        pattern: [
+            "11111111",
+            "11111111",
+            "11111111",
+            "11111111",
+            "11111111",
+            "11111111",
+            "gap",
+            "00000111",
+            "00000111",
+            "00000111",
+            "00000111",
+            "11111111",
+            "11111111",
+            "11111111",
+            "11111100",
+            "01111100"
+        ],
+        entranceDirection: .right
+    )
+}

--- a/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/Model/ChapelSeatMapModels.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/Model/ChapelSeatMapModels.swift
@@ -1,0 +1,109 @@
+//
+//  ChapelSeatMapModels.swift
+//  Soomsil-USaint
+//
+//  Created by 정민지 on 5/12/26.
+//
+
+import Foundation
+
+struct ChapelSeatZone: Identifiable {
+    let id: String
+    let columns: Int
+    let rows: [ChapelSeatRow]
+    let aisleAfterRows: Set<Int>
+    let entranceDirection: ChapelSeatEntranceDirection
+}
+
+struct ChapelSeatRow {
+    let seats: [Int?]
+
+    var seatCount: Int {
+        seats.compactMap { $0 }.count
+    }
+}
+
+enum ChapelSeatEntranceDirection {
+    case left
+    case right
+
+    var directionText: String {
+        switch self {
+        case .left:
+            return TextLiteral.ChapelSeatMap.leftDirection
+        case .right:
+            return TextLiteral.ChapelSeatMap.rightDirection
+        }
+    }
+}
+
+struct ChapelSeatLocation {
+    let zone: String
+    let row: Int?
+    let column: Int?
+
+    var guideText: String {
+        let zone = ChapelSeatZone.definition(for: zone)
+        let entranceDirection = zone?.entranceDirection(row: row, column: column)
+
+        return TextLiteral.ChapelSeatLocationView.seatGuide(
+            entranceDirection: entranceDirection?.directionText ?? TextLiteral.ChapelSeatMap.leftDirection,
+            row: row,
+            seatIndexFromEntrance: zone?.seatIndexFromEntrance(row: row, column: column)
+        )
+    }
+
+    init(seatPosition: String) {
+        let parts = seatPosition
+            .components(separatedBy: CharacterSet(charactersIn: TextLiteral.ChapelSeatInfoView.zoneSeparator))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        zone = parts.first?.uppercased() ?? TextLiteral.ChapelSeatInfoView.defaultZone
+
+        if parts.count >= 3 {
+            row = Int(parts[1])
+            column = Int(parts[2])
+        } else if let seatNumber = parts.dropFirst().first.flatMap(Int.init) {
+            row = ((seatNumber - 1) / 4) + 1
+            column = ((seatNumber - 1) % 4) + 1
+        } else {
+            row = nil
+            column = nil
+        }
+    }
+}
+
+extension ChapelSeatZone {
+    func entranceDirection(row: Int?, column: Int?) -> ChapelSeatEntranceDirection {
+        guard [ChapelSeatZone.c.id, ChapelSeatZone.h.id].contains(id),
+              let row,
+              let column,
+              rows.indices.contains(row - 1) else {
+            return entranceDirection
+        }
+
+        let seatCount = rows[row - 1].seatCount
+        return column <= Int(ceil(Double(seatCount) / 2)) ? .left : .right
+    }
+
+    func seatIndexFromEntrance(row: Int?, column: Int?) -> Int? {
+        guard let row,
+              let column,
+              rows.indices.contains(row - 1) else {
+            return nil
+        }
+
+        let seats = rows[row - 1].seats
+        guard seats.contains(column) else {
+            return nil
+        }
+
+        switch entranceDirection(row: row, column: column) {
+        case .left:
+            return column
+        case .right:
+            return rows[row - 1].seatCount - column + 1
+        }
+    }
+}

--- a/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatLocationView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatLocationView.swift
@@ -1,0 +1,107 @@
+//
+//  ChapelSeatLocationView.swift
+//  Soomsil-USaint
+//
+//  Created by 정민지 on 5/12/26.
+//
+
+import SwiftUI
+
+import ComposableArchitecture
+
+/// 채플 좌석 위치 화면
+struct ChapelSeatLocationView: View {
+    // MARK: - Properties
+
+    let store: StoreOf<ChapelSeatLocationReducer>
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            headerView
+
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 4) {
+                    ChapelSeatInfoView(
+                        type: .summaryCard,
+                        chapelCard: store.chapelCard
+                    )
+
+                    ZoomableChapelSeatMapView(seatLocation: store.seatLocation)
+
+                    Text(
+                        store.seatLocation.guideText
+                    )
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(.slate500)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 16)
+            }
+        }
+        .background(.white)
+    }
+}
+
+// MARK: - View
+
+private extension ChapelSeatLocationView {
+    var headerView: some View {
+        HStack(alignment: .center) {
+            Button {
+                store.send(.backButtonTapped)
+            } label: {
+                Image("ic_arrow_left_line")
+                    .resizable()
+                    .frame(width: 24, height: 24)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
+
+            Text(TextLiteral.ChapelSeatLocationView.title)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.navy900)
+
+            Spacer()
+
+            Button {
+                store.send(.infoButtonTapped)
+            } label: {
+                Icon.info
+                    .renderingMode(.template)
+                    .foregroundStyle(.navy900)
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(TextLiteral.ChapelSeatLocationView.title)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(.slate100)
+                .frame(height: 1)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ChapelSeatLocationView(
+        store: Store(
+            initialState: ChapelSeatLocationReducer.State(
+                chapelCard: ChapelCard(
+                    attendance: 5,
+                    seatPosition: "H-1-4",
+                    floorLevel: 1
+                )
+            )
+        ) {
+            ChapelSeatLocationReducer()
+        }
+    )
+}

--- a/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatLocationView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatLocationView.swift
@@ -19,8 +19,6 @@ struct ChapelSeatLocationView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            headerView
-
             ScrollView(showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 4) {
                     ChapelSeatInfoView(
@@ -42,48 +40,32 @@ struct ChapelSeatLocationView: View {
             }
         }
         .background(.white)
-    }
-}
-
-// MARK: - View
-
-private extension ChapelSeatLocationView {
-    var headerView: some View {
-        HStack(alignment: .center) {
-            Button {
-                store.send(.backButtonTapped)
-            } label: {
-                Image("ic_arrow_left_line")
-                    .resizable()
-                    .frame(width: 24, height: 24)
+        .navigationTitle(TextLiteral.ChapelSeatLocationView.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    store.send(.backButtonTapped)
+                } label: {
+                    Image("ic_arrow_left_line")
+                        .renderingMode(.template)
+                        .resizable()
+                        .frame(width: 24, height: 24)
+                        .foregroundStyle(.navy900)
+                }
             }
-            .buttonStyle(.plain)
-
-            Spacer()
-
-            Text(TextLiteral.ChapelSeatLocationView.title)
-                .font(.system(size: 18, weight: .bold))
-                .foregroundStyle(.navy900)
-
-            Spacer()
-
-            Button {
-                store.send(.infoButtonTapped)
-            } label: {
-                Icon.info
-                    .renderingMode(.template)
-                    .foregroundStyle(.navy900)
-                    .frame(width: 22, height: 22)
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    store.send(.infoButtonTapped)
+                } label: {
+                    Icon.info
+                        .renderingMode(.template)
+                        .foregroundStyle(.navy900)
+                        .frame(width: 22, height: 22)
+                }
+                .accessibilityLabel(TextLiteral.ChapelSeatLocationView.title)
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel(TextLiteral.ChapelSeatLocationView.title)
-        }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 16)
-        .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(.slate100)
-                .frame(height: 1)
         }
     }
 }
@@ -91,17 +73,19 @@ private extension ChapelSeatLocationView {
 // MARK: - Preview
 
 #Preview {
-    ChapelSeatLocationView(
-        store: Store(
-            initialState: ChapelSeatLocationReducer.State(
-                chapelCard: ChapelCard(
-                    attendance: 5,
-                    seatPosition: "H-1-4",
-                    floorLevel: 1
+    NavigationStack {
+        ChapelSeatLocationView(
+            store: Store(
+                initialState: ChapelSeatLocationReducer.State(
+                    chapelCard: ChapelCard(
+                        attendance: 5,
+                        seatPosition: "H-1-4",
+                        floorLevel: 1
+                    )
                 )
-            )
-        ) {
-            ChapelSeatLocationReducer()
-        }
-    )
+            ) {
+                ChapelSeatLocationReducer()
+            }
+        )
+    }
 }

--- a/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatMapView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatMapView.swift
@@ -1,0 +1,283 @@
+//
+//  ChapelSeatMapView.swift
+//  Soomsil-USaint
+//
+//  Created by 정민지 on 5/12/26.
+//
+
+import SwiftUI
+
+/// 확대 가능한 채플 좌석표
+struct ZoomableChapelSeatMapView: View {
+    // MARK: - Properties
+
+    let seatLocation: ChapelSeatLocation
+
+    @State private var zoomScale: CGFloat = 1
+    @State private var lastZoomScale: CGFloat = 1
+    @State private var offset: CGSize = .zero
+    @State private var lastOffset: CGSize = .zero
+
+    private let mapWidth: CGFloat = 820
+    private let mapHeight: CGFloat = 620
+    private let indicatorHeight: CGFloat = 16
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 14) {
+            ZStack {
+                GeometryReader { proxy in
+                    let fitScale = min(proxy.size.width / mapWidth, proxy.size.height / mapHeight)
+                    let scaledSize = CGSize(
+                        width: mapWidth * fitScale * zoomScale,
+                        height: mapHeight * fitScale * zoomScale
+                    )
+                    let boundedOffset = clampedOffset(
+                        offset,
+                        contentSize: scaledSize,
+                        containerSize: proxy.size
+                    )
+
+                    ChapelSeatMapView(seatLocation: seatLocation)
+                        .frame(width: mapWidth, height: mapHeight)
+                        .scaleEffect(fitScale * zoomScale)
+                        .frame(width: scaledSize.width, height: scaledSize.height)
+                        .position(
+                            x: proxy.size.width / 2 + boundedOffset.width,
+                            y: proxy.size.height / 2 + boundedOffset.height
+                        )
+                        .gesture(
+                            MagnificationGesture()
+                                .onChanged { value in
+                                    zoomScale = min(max(lastZoomScale * value, 1), 4)
+                                    offset = clampedOffset(
+                                        offset,
+                                        contentSize: scaledSize,
+                                        containerSize: proxy.size
+                                    )
+                                }
+                                .onEnded { _ in
+                                    zoomScale = min(max(zoomScale, 1), 4)
+                                    lastZoomScale = zoomScale
+                                    offset = clampedOffset(
+                                        offset,
+                                        contentSize: scaledSize,
+                                        containerSize: proxy.size
+                                    )
+                                    lastOffset = offset
+                                }
+                        )
+                        .simultaneousGesture(
+                            DragGesture()
+                                .onChanged { value in
+                                    guard zoomScale > 1 else { return }
+
+                                    offset = clampedOffset(
+                                        CGSize(
+                                            width: lastOffset.width + value.translation.width,
+                                            height: lastOffset.height + value.translation.height
+                                        ),
+                                        contentSize: scaledSize,
+                                        containerSize: proxy.size
+                                    )
+                                }
+                                .onEnded { _ in
+                                    lastOffset = offset
+                                }
+                        )
+                }
+            }
+            .aspectRatio(mapWidth / mapHeight, contentMode: .fit)
+            .clipped()
+
+            seatIndicatorView
+                .frame(height: indicatorHeight)
+        }
+        .padding(.vertical, 18)
+        .padding(.horizontal, 24)
+        .frame(maxWidth: .infinity)
+        .background(.gray25)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(.slate100, lineWidth: 1)
+        )
+        .onTapGesture(count: 2) {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                zoomScale = 1
+                lastZoomScale = 1
+                offset = .zero
+                lastOffset = .zero
+            }
+        }
+    }
+
+    private var seatIndicatorView: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "arrow.up")
+                .font(.system(size: 13, weight: .bold))
+
+            Text(TextLiteral.ChapelSeatLocationView.selectedSeatTitle)
+                .font(.system(size: 13, weight: .semibold))
+        }
+        .foregroundStyle(.blue500)
+    }
+
+    private func clampedOffset(
+        _ offset: CGSize,
+        contentSize: CGSize,
+        containerSize: CGSize
+    ) -> CGSize {
+        let maxX = max((contentSize.width - containerSize.width) / 2, 0)
+        let maxY = max((contentSize.height - containerSize.height) / 2, 0)
+
+        return CGSize(
+            width: min(max(offset.width, -maxX), maxX),
+            height: min(max(offset.height, -maxY), maxY)
+        )
+    }
+}
+
+/// 채플 좌석표
+struct ChapelSeatMapView: View {
+    // MARK: - Properties
+
+    let seatLocation: ChapelSeatLocation
+
+    private let zoneRows: [[ChapelSeatZone]] = [
+        [.a, .b, .c, .d, .e],
+        [.f, .g, .h, .i, .j]
+    ]
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 28) {
+            Text(TextLiteral.ChapelSeatLocationView.stageTitle)
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 58)
+                .background(.gray800)
+
+            VStack(spacing: 38) {
+                ForEach(zoneRows.indices, id: \.self) { rowIndex in
+                    HStack(alignment: .top, spacing: 22) {
+                        ForEach(zoneRows[rowIndex]) { zone in
+                            ChapelSeatZoneView(
+                                zone: zone,
+                                seatLocation: seatLocation
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 26)
+        .padding(.vertical, 24)
+        .background(.gray25)
+    }
+}
+
+// MARK: - Seat Zone
+
+private struct ChapelSeatZoneView: View {
+    // MARK: - Properties
+
+    let zone: ChapelSeatZone
+    let seatLocation: ChapelSeatLocation
+
+    private let seatSize: CGFloat = 7
+    private let seatGap: CGFloat = 3
+    private let rowGap: CGFloat = 10
+
+    private var selectedRow: Int? {
+        guard seatLocation.zone == zone.id else {
+            return nil
+        }
+        return seatLocation.row
+    }
+
+    private var selectedColumn: Int? {
+        guard seatLocation.zone == zone.id else {
+            return nil
+        }
+        return seatLocation.column
+    }
+
+    private var zoneWidth: CGFloat {
+        CGFloat(zone.columns) * seatSize + CGFloat(zone.columns - 1) * seatGap
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text(zone.id)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundStyle(.gray800)
+
+            VStack(spacing: seatGap) {
+                ForEach(zone.rows.indices, id: \.self) { rowIndex in
+                    HStack(spacing: seatGap) {
+                        ForEach(zone.rows[rowIndex].seats.indices, id: \.self) { columnIndex in
+                            seatSlotView(
+                                seatColumn: zone.rows[rowIndex].seats[columnIndex],
+                                row: rowIndex + 1,
+                                slot: columnIndex + 1
+                            )
+                        }
+                    }
+
+                    if zone.aisleAfterRows.contains(rowIndex + 1) {
+                        Spacer()
+                            .frame(height: rowGap)
+                    }
+                }
+            }
+            .frame(width: zoneWidth)
+        }
+        .frame(width: 118)
+    }
+
+    @ViewBuilder
+    private func seatSlotView(seatColumn: Int?, row: Int, slot: Int) -> some View {
+        if let seatColumn {
+            seatView(row: row, column: seatColumn)
+        } else {
+            Color.clear
+                .frame(width: seatSize, height: seatSize)
+        }
+    }
+
+    private func seatView(row: Int, column: Int) -> some View {
+        let isSelected = selectedRow == row && selectedColumn == column
+
+        return RoundedRectangle(cornerRadius: 2, style: .continuous)
+            .fill(isSelected ? Color.blue500 : Color.gray200)
+            .frame(width: seatSize, height: seatSize)
+            .overlay {
+                if isSelected {
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .stroke(.blue500.opacity(0.35), lineWidth: 4)
+                }
+            }
+            .accessibilityLabel(
+                TextLiteral.ChapelSeatMap.accessibilityLabel(
+                    zone: zone.id,
+                    row: row,
+                    column: column
+                )
+            )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ZoomableChapelSeatMapView(
+        seatLocation: ChapelSeatLocation(seatPosition: "B-1-1")
+    )
+    .padding(24)
+}

--- a/Soomsil-USaint/Application/Feature/Chapel/View/ChapelSeatInfoView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/View/ChapelSeatInfoView.swift
@@ -88,6 +88,10 @@ struct ChapelSeatInfoView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .stroke(.slate100, lineWidth: 1)
+        )
     }
 
     private var actionCardBody: some View {

--- a/Soomsil-USaint/Application/Feature/MainTab/Core/MainTabReducer.swift
+++ b/Soomsil-USaint/Application/Feature/MainTab/Core/MainTabReducer.swift
@@ -13,6 +13,7 @@ struct MainTabReducer {
     struct State {
         var selectedTab: MainTabItem = .home
         var homeState: HomeReducer.State
+        var chapelState: ChapelReducer.State
         var settingState: SettingReducer.State = SettingReducer.State()
 
         init(studentInfo: StudentInfo, totalReportCard: TotalReportCard, chapelCard: ChapelCard) {
@@ -21,12 +22,14 @@ struct MainTabReducer {
                 totalReportCard: totalReportCard,
                 chapelCard: chapelCard
             )
+            chapelState = ChapelReducer.State(chapelCard: chapelCard)
         }
     }
 
     enum Action {
         case tabSelected(MainTabItem)
         case home(HomeReducer.Action)
+        case chapel(ChapelReducer.Action)
         case setting(SettingReducer.Action)
     }
 
@@ -39,12 +42,18 @@ struct MainTabReducer {
             case .home(.chapelAttendancePressed):
                 state.selectedTab = .chapel
                 return .none
+            case .home(.getChapelDataResponse(.success(let chapelCard))):
+                state.chapelState.updateChapelCard(chapelCard)
+                return .none
             default:
                 return .none
             }
         }
         Scope(state: \.homeState, action: \.home) {
             HomeReducer()
+        }
+        Scope(state: \.chapelState, action: \.chapel) {
+            ChapelReducer()
         }
         Scope(state: \.settingState, action: \.setting) {
             SettingReducer()

--- a/Soomsil-USaint/Application/Feature/MainTab/View/MainTabView.swift
+++ b/Soomsil-USaint/Application/Feature/MainTab/View/MainTabView.swift
@@ -28,7 +28,7 @@ struct MainTabView: View {
         case .home:
             HomeView(store: store.scope(state: \.homeState, action: \.home))
         case .chapel:
-            ChapelView(chapelCard: store.homeState.chapelCard)
+            ChapelView(store: store.scope(state: \.chapelState, action: \.chapel))
         case .notification:
             placeholderView(TextLiteral.MainTabView.notificationPlaceholder)
         case .my:
@@ -49,7 +49,9 @@ struct MainTabView: View {
         switch store.selectedTab {
         case .home:
             store.homeState.path.isEmpty
-        case .chapel, .notification, .my:
+        case .chapel:
+            store.chapelState.path.isEmpty
+        case .notification, .my:
             true
         }
     }

--- a/Soomsil-USaint/Data/Model/ChapelCard.swift
+++ b/Soomsil-USaint/Data/Model/ChapelCard.swift
@@ -30,7 +30,7 @@ public struct ChapelCard: Hashable {
     static func inactive() -> ChapelCard {
         return ChapelCard(
             attendance: 0,
-            seatPosition: "이번 학기 채플 수강 없음",
+            seatPosition: TextLiteral.ChapelCard.inactiveSeatPosition,
             floorLevel: 0,
             status: .inactive
         )

--- a/Soomsil-USaint/Global/Utils/TextLiteral.swift
+++ b/Soomsil-USaint/Global/Utils/TextLiteral.swift
@@ -153,6 +153,12 @@ enum TextLiteral {
         }
     }
 
+    // MARK: - ChapelCard
+
+    enum ChapelCard {
+        static let inactiveSeatPosition = "이번 학기 채플 수강 없음"
+    }
+
     // MARK: - ChapelSeatInfoView
 
     enum ChapelSeatInfoView {
@@ -167,6 +173,68 @@ enum TextLiteral {
             seatZone: String
         ) -> String {
             "\(floorLevel)층 앞자리 · \(seatZone)구역"
+        }
+    }
+
+    // MARK: - ChapelSeatLocationView
+
+    enum ChapelSeatLocationView {
+        static let title = "내 좌석 위치"
+        static let stageTitle = "STAGE"
+        static let selectedSeatTitle = "이 자리에요"
+
+        static func seatGuide(
+            entranceDirection: String,
+            row: Int?,
+            seatIndexFromEntrance: Int?
+        ) -> String {
+            guard let row, let seatIndexFromEntrance else {
+                return "좌석표에서 파란색으로 표시된 자리가 내 자리예요"
+            }
+
+            return "입구에서 \(entranceDirection)으로 입장해 \(ordinal(row)) 줄 \(ordinal(seatIndexFromEntrance)) 자리예요"
+        }
+
+        private static func ordinal(_ number: Int) -> String {
+            switch number {
+            case 1:
+                return "첫 번째"
+            case 2:
+                return "두 번째"
+            case 3:
+                return "세 번째"
+            case 4:
+                return "네 번째"
+            case 5:
+                return "다섯 번째"
+            case 6:
+                return "여섯 번째"
+            case 7:
+                return "일곱 번째"
+            case 8:
+                return "여덟 번째"
+            case 9:
+                return "아홉 번째"
+            case 10:
+                return "열 번째"
+            default:
+                return "\(number)번째"
+            }
+        }
+    }
+
+    // MARK: - ChapelSeatMap
+
+    enum ChapelSeatMap {
+        static let leftDirection = "좌측"
+        static let rightDirection = "우측"
+
+        static func accessibilityLabel(
+            zone: String,
+            row: Int,
+            column: Int
+        ) -> String {
+            "\(zone)구역 \(row)번째 줄 \(column)번째 자리"
         }
     }
 


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->

- [x] ChapelSeatLocationView 구현
- [x] ChapelView와 연결

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #163 
- 피그마 : 
- 관련 문서 :
- close: #163 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->

  ### 채플 좌석 위치 화면 추가

  - 채플 탭에서 내 좌석 카드 선택 시 `ChapelSeatLocationView`로 이동하도록 구현
  했습니다.
  - 좌석 위치 화면에서는 아래 정보를 한 화면에서 확인할 수 있도록 구성했습니다.
    - 내 좌석 정보 카드
    - 확대 가능한 채플 좌석표
    - 선택된 좌석 안내 문구
  - 좌석 위치 화면의 네비게이션 바는 기존 시스템 navigation bar를 사용하도록 정
  리했습니다.
    - 좌측: 뒤로가기 버튼
    - 중앙: `내 좌석 위치` 타이틀
    - 우측: info 버튼

  ### Navigation 구조 정리

  - 기존에 임시로 사용하던 `fullScreenCover` 방식 대신 `NavigationStack(path:)`
  기반 push 이동으로 변경했습니다.
  - `ChapelReducer`에 `Path`를 추가해 좌석 위치 화면 이동 상태를 reducer에서 관
  리하도록 했습니다.
  - `ChapelView`는 `NavigationStack`을 사용하고, 좌석 카드 클릭 시 path에
  `ChapelSeatLocationReducer.State`를 append하도록 처리했습니다.
  - 좌석 위치 화면에 진입한 경우 하단 탭바가 보이지 않도록 `MainTabView`의 탭바
  표시 조건을 수정했습니다.

  ### Reducer 역할 분리

  - `ChapelReducer`
    - 채플 탭 화면의 상태와 사용자 액션을 관리합니다.
    - 좌석 카드 클릭 시 좌석 위치 화면으로 이동합니다.
    - 채플 정보가 갱신될 때 내부 상태를 갱신합니다.

  - `ChapelSeatLocationReducer`
    - 좌석 위치 화면 전용 상태를 관리합니다.
    - `ChapelCard` 기반으로 현재 좌석 위치 정보를 계산합니다.
    - 뒤로가기 및 info 버튼 액션을 처리합니다.

  ### 좌석표 View 분리

  - `ChapelSeatLocationView`
    - 좌석 위치 화면의 전체 레이아웃을 담당합니다.
    - 내 좌석 카드, 좌석표, 안내 문구를 조합합니다.

  - `ZoomableChapelSeatMapView`
    - 좌석표 확대/이동 동작을 담당합니다.
    - 기본 상태에서는 전체 좌석표가 한눈에 보이도록 비율을 맞춥니다.
    - pinch gesture로 확대할 수 있고, 확대 상태에서는 drag로 좌석표를 이동할 수
  있습니다.
    - 확대 전에는 `GeometryReader` 영역과 좌석표 표시 높이가 같은 기준을 사용하
  도록 정리했습니다.

  - `ChapelSeatMapView`
    - 실제 좌석표 UI를 렌더링합니다.
    - 설교단, 구역 라벨, 좌석 블록, 선택 좌석 표시를 담당합니다.

  ### 좌석 데이터 분리

  - 좌석 배치 데이터를 `ChapelSeatMapData`로 분리했습니다.
  - 좌석표 렌더링에 필요한 모델을 별도 모델 파일로 분리했습니다.
    - `ChapelSeatZone`
    - `ChapelSeatRow`
    - `ChapelSeatEntranceDirection`
    - `ChapelSeatLocation`
  - 좌석 배치는 `0/1/gap` 패턴 기반으로 관리합니다.
    - `1`: 좌석 있음
    - `0`: 빈칸
    - `gap`: 통로 또는 블록 간 여백
  - A~J 구역별 좌석 형태를 실제 좌석표에 맞춰 반영했습니다.
  - A/E, F/J처럼 좌우 형태가 다른 구역도 패턴 기반으로 표현했습니다.
  - C/H처럼 중앙 구역은 더 넓은 좌석 블록으로 표현했습니다.

  ### 좌석 위치 계산 방식

  - 좌석 위치는 `구역-행-열` 형식을 기준으로 파싱합니다.
    - 예: `B-12-4`
  - 좌석 번호 계산은 실제 좌석 번호 기준으로 처리했습니다.
    - 예: `0011111`인 경우 첫 번째 `1`은 화면 슬롯상 3번째 칸이지만, 실제 좌석
  번호는 1번입니다.
  - 선택 좌석은 파싱된 구역/행/열에 맞춰 좌석표에서 파란색으로 표시됩니다.
  - 선택 좌석 안내 문구는 입구 방향과 실제 좌석 번호 기준으로 계산됩니다.
    - 예: `입구에서 좌측으로 입장해 세 번째 줄 네 번째 자리예요`
  - 행 번호는 gap을 제외한 실제 행 기준이 아니라, 입력으로 들어온 행 번호 기준을
  그대로 사용하도록 정리했습니다.

  ### 좌석표 UX 개선

  - 기본 상태에서 전체 좌석표가 카드 안에 한눈에 보이도록 조정했습니다.
  - 좌석표 확대 시 사용자가 원하는 위치로 이동해 좌석을 확인할 수 있도록 했습니
  다.
  - 선택 좌석 안내 문구가 좌석과 겹치지 않도록 좌석표 아래 별도 영역에 표시했습
  니다.
  - 좌석 구역 간 간격이 어색하게 벌어지지 않도록 동일한 spacing 기준으로 정리했
  습니다.
  - 좌석표의 시각 스타일은 단순한 좌석 블록 UI를 유지하면서, 선택 좌석만 강조되
  도록 했습니다.


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

<img width="298" height="289" alt="스크린샷 2026-05-12 오후 2 49 02" src="https://github.com/user-attachments/assets/b8f4f5be-103f-4478-a763-7d5150834c0d" />


## 🔥 Test
<!-- Test -->

https://github.com/user-attachments/assets/2636f7d8-a103-44d4-97d7-f27ed40176dd