### PR TITLE
[#169] 알림 페이지 v2 디자인 적용

### DIFF
--- a/Soomsil-USaint/Application/AppReducer.swift
+++ b/Soomsil-USaint/Application/AppReducer.swift
@@ -29,6 +29,7 @@ struct AppReducer {
         case splash(SplashReducer.Action)
         case login(LoginReducer.Action)
         case mainTab(MainTabReducer.Action)
+        case notificationOpened(USaintNotificationRoute)
     }
     
     @Dependency(\.gradeClient) var gradeClient
@@ -44,16 +45,21 @@ struct AppReducer {
                 }
             case .splash(.initResponse(.success(let (studentInfo, totalReportCard, chapelCard)))):
                 state = .loggedIn(MainTabReducer.State(studentInfo: studentInfo, totalReportCard: totalReportCard, chapelCard: chapelCard))
-                return .none
+                return routePendingNotificationIfNeeded()
             case .splash(.initResponse(.failure)):
                 state = .loggedOut(LoginReducer.State())
                 return .none
             case .login(.loginResponse(.success(let (info, report, chapel)))):
                 state = .loggedIn(MainTabReducer.State(studentInfo: info, totalReportCard: report, chapelCard: chapel))
-                return .none
+                return routePendingNotificationIfNeeded()
             case .mainTab(.setting(.logoutCompleted)):
                 state = .initial(SplashReducer.State())
                 return .none
+            case .notificationOpened(let route):
+                guard case .loggedIn = state else {
+                    return .none
+                }
+                return .send(.mainTab(.notificationOpened(route)))
             default:
                 return .none
             }
@@ -122,5 +128,16 @@ struct AppReducer {
                 newLectures: grades.toLectureDetails()
             )
         }
+    }
+
+    private func routePendingNotificationIfNeeded() -> Effect<Action> {
+        guard let routeValue = UserDefaults.standard.string(forKey: NotificationStorageKey.pendingRoute),
+              let route = USaintNotificationRoute(rawValue: routeValue)
+        else {
+            return .none
+        }
+
+        UserDefaults.standard.removeObject(forKey: NotificationStorageKey.pendingRoute)
+        return .send(.mainTab(.notificationOpened(route)))
     }
 }

--- a/Soomsil-USaint/Application/AppView.swift
+++ b/Soomsil-USaint/Application/AppView.swift
@@ -13,19 +13,29 @@ struct AppView: View {
     @Bindable var store: StoreOf<AppReducer>
     
     var body: some View {
-        switch store.state {
-        case .initial:
-            if let store = store.scope(state: \.initial, action: \.splash) {
-                SplashView(store: store)
+        Group {
+            switch store.state {
+            case .initial:
+                if let store = store.scope(state: \.initial, action: \.splash) {
+                    SplashView(store: store)
+                }
+            case .loggedOut:
+                if let store = store.scope(state: \.loggedOut, action: \.login) {
+                    LoginView(store: store)
+                }
+            case .loggedIn:
+                if let store = store.scope(state: \.loggedIn, action: \.mainTab) {
+                    MainTabView(store: store)
+                }
             }
-        case .loggedOut:
-            if let store = store.scope(state: \.loggedOut, action: \.login) {
-                LoginView(store: store)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .usaintNotificationOpened)) { notification in
+            guard let routeValue = notification.userInfo?[NotificationUserInfoKey.route] as? String,
+                  let route = USaintNotificationRoute(rawValue: routeValue) else {
+                return
             }
-        case .loggedIn:
-            if let store = store.scope(state: \.loggedIn, action: \.mainTab) {
-                MainTabView(store: store)
-            }
+            UserDefaults.standard.removeObject(forKey: NotificationStorageKey.pendingRoute)
+            store.send(.notificationOpened(route))
         }
     }
 }

--- a/Soomsil-USaint/Application/Feature/Chapel/Chapel/View/ChapelView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/Chapel/View/ChapelView.swift
@@ -49,8 +49,6 @@ struct ChapelView: View {
                 }
 
                 Spacer(minLength: 0)
-
-                attendanceArea
             }
             .background(.white)
             .toolbar(.hidden, for: .navigationBar)
@@ -89,35 +87,6 @@ private extension ChapelView {
         .padding(.vertical, 12)
     }
 
-    var attendanceArea: some View {
-        VStack(spacing: 8) {
-            Button {
-                store.send(.attendanceButtonTapped)
-            } label: {
-                HStack(spacing: 8) {
-                    Icon.qr
-                        .renderingMode(.template)
-                        .foregroundStyle(.white)
-                        .frame(width: 18, height: 18)
-
-                    Text(TextLiteral.ChapelView.attendanceButtonTitle)
-                        .font(.system(size: 16, weight: .bold))
-                }
-                .foregroundStyle(.white)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 18)
-                .background(.gray950)
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-            }
-            .buttonStyle(.plain)
-
-            Text(TextLiteral.ChapelView.attendanceGuide)
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(.gray500)
-        }
-        .padding(.horizontal, 20)
-        .padding(.bottom, 32)
-    }
 }
 
 // MARK: - Preview

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 import ComposableArchitecture
-import UIKit
 
 @Reducer
 struct HomeReducer {
@@ -40,6 +39,7 @@ struct HomeReducer {
         case path(StackActionOf<Path>)
         case onAppear
         case checkPushAuthorizationResponse(Result<Bool, Error>)
+        case notificationPermissionResponse(Result<Bool, Error>)
         case semesterDetailPressed
 
         case currentSemesterGradesPressed
@@ -85,14 +85,15 @@ struct HomeReducer {
                         await send(.getGradeDataResponse(.failure(error)))
                     }
 
-                    // 알림 권한 요청
-                    await send(.checkPushAuthorizationResponse(Result {
-                        if (isFirst) {
-                            return try await localNotificationClient.requestPushAuthorization()
-                        } else {
-                            return await localNotificationClient.getPushAuthorizationStatus()
-                        }
-                    }))
+                    if isFirst {
+                        await send(.notificationPermissionResponse(Result {
+                            try await localNotificationClient.requestPushAuthorization()
+                        }))
+                    } else {
+                        await send(.checkPushAuthorizationResponse(Result {
+                            await localNotificationClient.getPushAuthorizationStatus()
+                        }))
+                    }
 
                     // 서버에서 최신 값 다시 fetch
                     await send(.fetchGradeDataResponse(Result {
@@ -122,6 +123,13 @@ struct HomeReducer {
                 return .none
             case .checkPushAuthorizationResponse(.failure(let error)):
                 debugPrint("Home Reducer: CheckPushAuthorization Error - \(error)")
+                return .none
+            case .notificationPermissionResponse(.success(let granted)):
+                state.$permission.withLock { $0 = granted }
+                return .none
+            case .notificationPermissionResponse(.failure(let error)):
+                debugPrint("Home Reducer: RequestPushAuthorization Error - \(error)")
+                state.$permission.withLock { $0 = false }
                 return .none
             case .semesterDetailPressed:
                 state.path.append(.semesterDetail(SemesterDetailReducer.State()))

--- a/Soomsil-USaint/Application/Feature/MainTab/Core/MainTabReducer.swift
+++ b/Soomsil-USaint/Application/Feature/MainTab/Core/MainTabReducer.swift
@@ -31,6 +31,7 @@ struct MainTabReducer {
         case home(HomeReducer.Action)
         case chapel(ChapelReducer.Action)
         case setting(SettingReducer.Action)
+        case notificationOpened(USaintNotificationRoute)
     }
 
     var body: some Reducer<State, Action> {
@@ -44,6 +45,12 @@ struct MainTabReducer {
                 return .none
             case .home(.getChapelDataResponse(.success(let chapelCard))):
                 state.chapelState.updateChapelCard(chapelCard)
+                return .none
+            case .notificationOpened(.chapel):
+                state.selectedTab = .chapel
+                return .none
+            case .notificationOpened(.notification):
+                state.selectedTab = .notification
                 return .none
             default:
                 return .none

--- a/Soomsil-USaint/Application/Feature/MainTab/View/MainTabView.swift
+++ b/Soomsil-USaint/Application/Feature/MainTab/View/MainTabView.swift
@@ -11,15 +11,26 @@ struct MainTabView: View {
     @Bindable var store: StoreOf<MainTabReducer>
 
     var body: some View {
-        tabContent
-            .safeAreaInset(edge: .bottom) {
-                if showsTabBar {
-                    CustomTabBar(selectedTab: Binding(
-                        get: { store.selectedTab },
-                        set: { store.send(.tabSelected($0)) }
-                    ))
+        ZStack {
+            tabContent
+                .safeAreaInset(edge: .bottom) {
+                    if showsTabBar {
+                        CustomTabBar(selectedTab: Binding(
+                            get: { store.selectedTab },
+                            set: { store.send(.tabSelected($0)) }
+                        ))
+                    }
                 }
+
+            if store.selectedTab == .my && store.settingState.showsLogoutDialog {
+                LogoutDialogView(
+                    cancel: { store.send(.setting(.logoutCancelTapped)) },
+                    confirm: { store.send(.setting(.logoutConfirmed)) }
+                )
+                .transition(.opacity)
             }
+        }
+        .animation(.easeInOut(duration: 0.18), value: store.settingState.showsLogoutDialog)
     }
 
     @ViewBuilder
@@ -30,7 +41,7 @@ struct MainTabView: View {
         case .chapel:
             ChapelView(store: store.scope(state: \.chapelState, action: \.chapel))
         case .notification:
-            placeholderView(TextLiteral.MainTabView.notificationPlaceholder)
+            NotificationView()
         case .my:
             SettingView(
                 store: store.scope(state: \.settingState, action: \.setting)

--- a/Soomsil-USaint/Application/Feature/Notification/View/NotificationSettingsContainerView.swift
+++ b/Soomsil-USaint/Application/Feature/Notification/View/NotificationSettingsContainerView.swift
@@ -1,0 +1,160 @@
+//
+//  NotificationSettingsContainerView.swift
+//  Soomsil-USaint
+//
+
+import SwiftUI
+import UIKit
+import UserNotifications
+
+import ComposableArchitecture
+
+struct NotificationSettingsContainerView: View {
+    let close: () -> Void
+
+    @Dependency(\.localNotificationClient) private var localNotificationClient
+
+    @AppStorage("permission") private var isPushNotificationEnabled = false
+    @AppStorage("courseRegistrationNotificationEnabled") private var isCourseRegistrationEnabled = true
+    @AppStorage("assignmentDeadlineNotificationEnabled") private var isAssignmentDeadlineEnabled = true
+    @AppStorage("gradeAnnouncementNotificationEnabled") private var isGradeAnnouncementEnabled = true
+    @AppStorage("chapelNotificationEnabled") private var isChapelEnabled = true
+    @AppStorage("marketingNotificationEnabled") private var isMarketingEnabled = false
+
+    @State private var authorizationStatus: UNAuthorizationStatus = .notDetermined
+
+    private var isSystemAuthorized: Bool {
+        authorizationStatus == .authorized || authorizationStatus == .provisional
+    }
+
+    var body: some View {
+        NotificationSettingsView(
+            isSystemAuthorized: isSystemAuthorized,
+            isPushNotificationEnabled: isPushNotificationEnabled && isSystemAuthorized,
+            isCourseRegistrationEnabled: isCourseRegistrationEnabled,
+            isAssignmentDeadlineEnabled: isAssignmentDeadlineEnabled,
+            isGradeAnnouncementEnabled: isGradeAnnouncementEnabled,
+            isChapelEnabled: isChapelEnabled,
+            isMarketingEnabled: isMarketingEnabled,
+            pushToggleChanged: updatePushNotification,
+            courseRegistrationToggleChanged: {
+                updateNotificationType(isOn: $0) {
+                    isCourseRegistrationEnabled = $0
+                }
+            },
+            assignmentDeadlineToggleChanged: {
+                updateNotificationType(isOn: $0) {
+                    isAssignmentDeadlineEnabled = $0
+                }
+            },
+            gradeAnnouncementToggleChanged: {
+                updateNotificationType(isOn: $0) {
+                    isGradeAnnouncementEnabled = $0
+                }
+            },
+            chapelToggleChanged: {
+                updateNotificationType(isOn: $0) {
+                    isChapelEnabled = $0
+                }
+            },
+            marketingToggleChanged: {
+                updateNotificationType(isOn: $0) {
+                    isMarketingEnabled = $0
+                }
+            },
+            sendTestNotification: sendTestNotification,
+            close: close
+        )
+        .task {
+            await refreshAuthorizationStatus()
+        }
+    }
+
+    @MainActor
+    private func refreshAuthorizationStatus() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        authorizationStatus = settings.authorizationStatus
+
+        if !isSystemAuthorized {
+            isPushNotificationEnabled = false
+        }
+    }
+
+    private func updatePushNotification(_ isOn: Bool) {
+        guard isOn else {
+            isPushNotificationEnabled = false
+            return
+        }
+
+        switch authorizationStatus {
+        case .authorized, .provisional:
+            isPushNotificationEnabled = true
+        case .notDetermined:
+            requestAuthorization()
+        case .denied, .ephemeral:
+            openSystemSettings()
+        @unknown default:
+            openSystemSettings()
+        }
+    }
+
+    private func updateNotificationType(isOn: Bool, assign: (Bool) -> Void) {
+        guard isSystemAuthorized, isPushNotificationEnabled else {
+            updatePushNotification(true)
+            return
+        }
+
+        assign(isOn)
+    }
+
+    private func requestAuthorization() {
+        Task {
+            let granted = (try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])) ?? false
+
+            await MainActor.run {
+                isPushNotificationEnabled = granted
+            }
+
+            await refreshAuthorizationStatus()
+        }
+    }
+
+    private func openSystemSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString),
+              UIApplication.shared.canOpenURL(url)
+        else { return }
+
+        UIApplication.shared.open(url)
+    }
+
+    private func sendTestNotification() {
+        Task {
+            let settings = await UNUserNotificationCenter.current().notificationSettings()
+            if settings.authorizationStatus == .notDetermined {
+                let granted = (try? await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound])) ?? false
+
+                await MainActor.run {
+                    isPushNotificationEnabled = granted
+                }
+
+                guard granted else { return }
+            } else if settings.authorizationStatus != .authorized && settings.authorizationStatus != .provisional {
+                await MainActor.run {
+                    openSystemSettings()
+                }
+                return
+            } else {
+                await MainActor.run {
+                    isPushNotificationEnabled = true
+                }
+            }
+
+            try? await localNotificationClient.setChapelPushNotification(
+                ChapelCard(attendance: 4, seatPosition: "B-12", floorLevel: 1)
+            )
+            try? await localNotificationClient.setAssignmentDeadlinePushNotification("데이터베이스", 1)
+            try? await localNotificationClient.setCourseRegistrationPushNotification(2)
+            try? await localNotificationClient.setLecturePushNotification("데이터베이스")
+        }
+    }
+}

--- a/Soomsil-USaint/Application/Feature/Notification/View/NotificationSettingsView.swift
+++ b/Soomsil-USaint/Application/Feature/Notification/View/NotificationSettingsView.swift
@@ -1,0 +1,233 @@
+//
+//  NotificationSettingsView.swift
+//  Soomsil-USaint
+//
+
+import SwiftUI
+
+struct NotificationSettingsView: View {
+    let isSystemAuthorized: Bool
+    let isPushNotificationEnabled: Bool
+    let isCourseRegistrationEnabled: Bool
+    let isAssignmentDeadlineEnabled: Bool
+    let isGradeAnnouncementEnabled: Bool
+    let isChapelEnabled: Bool
+    let isMarketingEnabled: Bool
+    let pushToggleChanged: (Bool) -> Void
+    let courseRegistrationToggleChanged: (Bool) -> Void
+    let assignmentDeadlineToggleChanged: (Bool) -> Void
+    let gradeAnnouncementToggleChanged: (Bool) -> Void
+    let chapelToggleChanged: (Bool) -> Void
+    let marketingToggleChanged: (Bool) -> Void
+    let sendTestNotification: () -> Void
+    let close: () -> Void
+
+    private var isNotificationTypeEnabled: Bool {
+        isSystemAuthorized && isPushNotificationEnabled
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            ScrollView(showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    sectionTitle(TextLiteral.NotificationSettingsView.receiveSectionTitle)
+
+                    NotificationSettingRow(
+                        title: TextLiteral.NotificationSettingsView.pushNotificationTitle,
+                        subtitle: isSystemAuthorized
+                            ? TextLiteral.NotificationSettingsView.pushNotificationSubtitle
+                            : TextLiteral.NotificationSettingsView.pushNotificationDeniedSubtitle,
+                        isOn: isPushNotificationEnabled,
+                        isEnabled: true,
+                        onChange: pushToggleChanged
+                    )
+
+                    sectionTitle(TextLiteral.NotificationSettingsView.typeSectionTitle)
+                        .padding(.top, 32)
+
+                    notificationTypeRows
+
+                    sectionTitle(TextLiteral.NotificationSettingsView.marketingSectionTitle)
+                        .padding(.top, 32)
+
+                    NotificationSettingRow(
+                        title: TextLiteral.NotificationSettingsView.marketingNotificationTitle,
+                        subtitle: TextLiteral.NotificationSettingsView.marketingNotificationSubtitle,
+                        isOn: isMarketingEnabled && isNotificationTypeEnabled,
+                        isEnabled: isNotificationTypeEnabled,
+                        onChange: marketingToggleChanged
+                    )
+
+#if DEBUG
+                    debugSection
+#endif
+                }
+                .padding(.horizontal, 22)
+                .padding(.top, 18)
+                .padding(.bottom, 44)
+            }
+        }
+        .background(.white)
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Button(action: close) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(.gray950)
+                    .frame(width: 28, height: 44)
+            }
+            .buttonStyle(.plain)
+
+            Text(TextLiteral.NotificationSettingsView.title)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.gray950)
+
+            Spacer()
+        }
+        .padding(.horizontal, 22)
+        .padding(.top, 8)
+        .padding(.bottom, 14)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(.slate100)
+                .frame(height: 1)
+        }
+    }
+
+    private var notificationTypeRows: some View {
+        VStack(spacing: 0) {
+            NotificationSettingRow(
+                title: TextLiteral.NotificationSettingsView.courseRegistrationTitle,
+                subtitle: TextLiteral.NotificationSettingsView.courseRegistrationSubtitle,
+                isOn: isCourseRegistrationEnabled && isNotificationTypeEnabled,
+                isEnabled: isNotificationTypeEnabled,
+                onChange: courseRegistrationToggleChanged
+            )
+
+            divider
+
+            NotificationSettingRow(
+                title: TextLiteral.NotificationSettingsView.assignmentDeadlineTitle,
+                subtitle: TextLiteral.NotificationSettingsView.assignmentDeadlineSubtitle,
+                isOn: isAssignmentDeadlineEnabled && isNotificationTypeEnabled,
+                isEnabled: isNotificationTypeEnabled,
+                onChange: assignmentDeadlineToggleChanged
+            )
+
+            divider
+
+            NotificationSettingRow(
+                title: TextLiteral.NotificationSettingsView.gradeAnnouncementTitle,
+                subtitle: TextLiteral.NotificationSettingsView.gradeAnnouncementSubtitle,
+                isOn: isGradeAnnouncementEnabled && isNotificationTypeEnabled,
+                isEnabled: isNotificationTypeEnabled,
+                onChange: gradeAnnouncementToggleChanged
+            )
+
+            divider
+
+            NotificationSettingRow(
+                title: TextLiteral.NotificationSettingsView.chapelTitle,
+                subtitle: TextLiteral.NotificationSettingsView.chapelSubtitle,
+                isOn: isChapelEnabled && isNotificationTypeEnabled,
+                isEnabled: isNotificationTypeEnabled,
+                onChange: chapelToggleChanged
+            )
+        }
+    }
+
+    private var divider: some View {
+        Rectangle()
+            .fill(.slate100)
+            .frame(height: 1)
+    }
+
+    private func sectionTitle(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 14, weight: .semibold))
+            .foregroundStyle(.slate400)
+            .padding(.bottom, 16)
+    }
+
+#if DEBUG
+    private var debugSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            sectionTitle(TextLiteral.NotificationSettingsView.debugSectionTitle)
+
+            Button(action: sendTestNotification) {
+                Text(TextLiteral.NotificationSettingsView.debugSendTestNotificationTitle)
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .background(isNotificationTypeEnabled ? .blue600 : .slate300)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .buttonStyle(.plain)
+            .disabled(!isNotificationTypeEnabled)
+
+            Text(TextLiteral.NotificationSettingsView.debugSendTestNotificationSubtitle)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.slate400)
+        }
+        .padding(.top, 32)
+    }
+#endif
+}
+
+private struct NotificationSettingRow: View {
+    let title: String
+    let subtitle: String
+    let isOn: Bool
+    let isEnabled: Bool
+    let onChange: (Bool) -> Void
+
+    var body: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(size: 17, weight: .bold))
+                    .foregroundStyle(isEnabled ? .gray950 : .slate400)
+
+                Text(subtitle)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.slate400)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { isOn },
+                set: { onChange($0) }
+            ))
+            .labelsHidden()
+            .tint(.blue600)
+            .disabled(!isEnabled)
+        }
+        .frame(minHeight: 80)
+    }
+}
+
+#Preview {
+    NotificationSettingsView(
+        isSystemAuthorized: true,
+        isPushNotificationEnabled: true,
+        isCourseRegistrationEnabled: true,
+        isAssignmentDeadlineEnabled: true,
+        isGradeAnnouncementEnabled: true,
+        isChapelEnabled: true,
+        isMarketingEnabled: false,
+        pushToggleChanged: { _ in },
+        courseRegistrationToggleChanged: { _ in },
+        assignmentDeadlineToggleChanged: { _ in },
+        gradeAnnouncementToggleChanged: { _ in },
+        chapelToggleChanged: { _ in },
+        marketingToggleChanged: { _ in },
+        sendTestNotification: {},
+        close: {}
+    )
+}

--- a/Soomsil-USaint/Application/Feature/Notification/View/NotificationView.swift
+++ b/Soomsil-USaint/Application/Feature/Notification/View/NotificationView.swift
@@ -1,0 +1,503 @@
+//
+//  NotificationView.swift
+//  Soomsil-USaint
+//
+
+import SwiftUI
+
+struct NotificationView: View {
+    @State private var selectedCategory: NotificationCategory = .all
+    @State private var hasUnreadNotifications = true
+    @State private var showsSettings = false
+
+    private var visibleSections: [NotificationSection] {
+        let unreadSections = NotificationSampleData.sections.map { section in
+            NotificationSection(
+                title: section.title,
+                notifications: section.notifications.map { notification in
+                    NotificationItem(
+                        title: notification.title,
+                        subtitle: notification.subtitle,
+                        time: notification.time,
+                        badge: notification.badge,
+                        category: notification.category,
+                        isRead: hasUnreadNotifications ? notification.isRead : true
+                    )
+                }
+            )
+        }
+
+        guard selectedCategory != .all else {
+            return unreadSections
+        }
+
+        return unreadSections.compactMap { section in
+            let notifications = section.notifications.filter { $0.category == selectedCategory }
+            return notifications.isEmpty ? nil : NotificationSection(title: section.title, notifications: notifications)
+        }
+    }
+
+    private var unreadCount: Int {
+        guard hasUnreadNotifications else { return 0 }
+        return NotificationSampleData.sections
+            .flatMap(\.notifications)
+            .filter { !$0.isRead }
+            .count
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 0) {
+                    summary
+                    featuredNotice
+                    categoryTabs
+                    retentionBanner
+                    notificationList
+                }
+                .padding(.bottom, 24)
+            }
+            .background(.white)
+        }
+        .background(.white)
+        .fullScreenCover(isPresented: $showsSettings) {
+            NotificationSettingsContainerView(
+                close: {
+                    showsSettings = false
+                }
+            )
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            Text(TextLiteral.NotificationView.title)
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(.gray950)
+
+            Spacer()
+
+            Button {
+                showsSettings = true
+            } label: {
+                Icon.alarmSetting
+                    .resizable()
+                    .frame(width: 22, height: 22)
+                    .frame(width: 44, height: 44)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(TextLiteral.NotificationSettingsView.title)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+
+    private var summary: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .bottom) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(TextLiteral.NotificationView.unreadTitle)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.slate300)
+
+                    HStack(alignment: .lastTextBaseline, spacing: 4) {
+                        Text("\(unreadCount)")
+                            .font(.system(size: 36, weight: .heavy))
+                            .foregroundStyle(.gray950)
+
+                        Text(TextLiteral.NotificationView.countUnit)
+                            .font(.system(size: 20, weight: .bold))
+                            .foregroundStyle(.gray950)
+                    }
+                }
+
+                Spacer()
+
+                Button {
+                    hasUnreadNotifications = false
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 11, weight: .bold))
+                        Text(TextLiteral.NotificationView.markAllReadButtonTitle)
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 9)
+                    .background(.blue600)
+                    .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .disabled(unreadCount == 0)
+                .opacity(unreadCount == 0 ? 0.45 : 1)
+            }
+
+            if unreadCount > 0 {
+                Label(TextLiteral.NotificationView.unreadDescription, systemImage: "info.circle")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.slate300)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 8)
+        .padding(.bottom, unreadCount > 0 ? 20 : 8)
+    }
+
+    private var featuredNotice: some View {
+        HStack(spacing: 14) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(TextLiteral.NotificationView.featuredTitle)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.gray950)
+
+                Text(TextLiteral.NotificationView.featuredSubtitle)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.slate300)
+            }
+
+            Spacer()
+
+            RoundedRectangle(cornerRadius: 4)
+                .fill(.gray150)
+                .frame(width: 16, height: 16)
+                .accessibilityHidden(true)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(.white)
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(.slate100, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+        .padding(.horizontal, 20)
+        .padding(.bottom, 16)
+    }
+
+    private var categoryTabs: some View {
+        HStack(spacing: 28) {
+            ForEach(NotificationCategory.allCases, id: \.self) { category in
+                Button {
+                    selectedCategory = category
+                } label: {
+                    VStack(spacing: 8) {
+                        Text(category.title)
+                            .font(.system(size: 14, weight: selectedCategory == category ? .semibold : .medium))
+                            .foregroundStyle(selectedCategory == category ? .gray950 : .slate300)
+
+                        Capsule()
+                            .fill(selectedCategory == category ? .gray950 : .white)
+                            .frame(width: selectedCategory == category ? 32 : 24, height: 2)
+                    }
+                    .padding(.vertical, 12)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(.slate100)
+                .frame(height: 1)
+        }
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(.slate100)
+                .frame(height: 1)
+        }
+    }
+
+    private var retentionBanner: some View {
+        Label(TextLiteral.NotificationView.retentionNotice, systemImage: "info.circle")
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(.slate500)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            .background(.gray25)
+    }
+
+    private var notificationList: some View {
+        VStack(spacing: 0) {
+            ForEach(visibleSections) { section in
+                NotificationSectionView(section: section)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 8)
+    }
+
+}
+
+private struct NotificationSectionView: View {
+    let section: NotificationSection
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                Text(section.title)
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.slate300)
+
+                Text("  ·  \(section.notifications.count)건")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.gray200)
+
+                Spacer()
+            }
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            ForEach(Array(section.notifications.enumerated()), id: \.element.id) { index, notification in
+                NotificationRowView(notification: notification)
+
+                if index < section.notifications.count - 1 {
+                    Divider()
+                        .foregroundStyle(.slate100)
+                }
+            }
+        }
+    }
+}
+
+private struct NotificationRowView: View {
+    let notification: NotificationItem
+
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(notification.title)
+                    .font(.system(size: 14, weight: notification.isRead ? .medium : .semibold))
+                    .foregroundStyle(notification.isRead ? .slate500 : .gray950)
+                    .lineLimit(1)
+
+                if let subtitle = notification.subtitle {
+                    HStack(spacing: 6) {
+                        Text(subtitle)
+
+                        if let time = notification.time {
+                            Circle()
+                                .fill(.slate300)
+                                .frame(width: 3, height: 3)
+
+                            Text(time)
+                        }
+                    }
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(notification.isRead ? .slate300 : .slate500)
+                    .lineLimit(1)
+                } else if let time = notification.time {
+                    Text(time)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.slate300)
+                }
+            }
+
+            Spacer(minLength: 12)
+
+            if let badge = notification.badge {
+                NotificationBadgeView(badge: badge)
+            }
+        }
+        .padding(.vertical, 12)
+        .opacity(notification.isRead ? 0.55 : 1)
+    }
+}
+
+private struct NotificationBadgeView: View {
+    let badge: NotificationBadge
+
+    var body: some View {
+        Text(badge.title)
+            .font(.system(size: 11, weight: .bold))
+            .foregroundStyle(badge.foregroundColor)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(badge.backgroundColor)
+            .overlay(
+                Capsule()
+                    .stroke(badge.borderColor, lineWidth: badge.hasBorder ? 1 : 0)
+            )
+            .clipShape(Capsule())
+    }
+}
+
+private enum NotificationCategory: CaseIterable {
+    case all
+    case academic
+    case classNotice
+
+    var title: String {
+        switch self {
+        case .all:
+            TextLiteral.NotificationView.allTabTitle
+        case .academic:
+            TextLiteral.NotificationView.academicTabTitle
+        case .classNotice:
+            TextLiteral.NotificationView.classTabTitle
+        }
+    }
+}
+
+private struct NotificationSection: Identifiable {
+    let id = UUID()
+    let title: String
+    let notifications: [NotificationItem]
+}
+
+private struct NotificationItem: Identifiable {
+    let id = UUID()
+    let title: String
+    let subtitle: String?
+    let time: String?
+    let badge: NotificationBadge?
+    let category: NotificationCategory
+    let isRead: Bool
+}
+
+private struct NotificationBadge {
+    let title: String
+    let foregroundColor: Color
+    let backgroundColor: Color
+    let borderColor: Color
+    let hasBorder: Bool
+
+    static func urgent(_ title: String) -> Self {
+        Self(
+            title: title,
+            foregroundColor: .error,
+            backgroundColor: .error.opacity(0.1),
+            borderColor: .clear,
+            hasBorder: false
+        )
+    }
+
+    static func warning(_ title: String) -> Self {
+        Self(
+            title: title,
+            foregroundColor: .orange500,
+            backgroundColor: .orange50,
+            borderColor: .clear,
+            hasBorder: false
+        )
+    }
+
+    static func neutral(_ title: String) -> Self {
+        Self(
+            title: title,
+            foregroundColor: .slate500,
+            backgroundColor: .gray25,
+            borderColor: .gray150,
+            hasBorder: true
+        )
+    }
+}
+
+private enum NotificationSampleData {
+    static let sections: [NotificationSection] = [
+        NotificationSection(
+            title: "오늘",
+            notifications: [
+                NotificationItem(
+                    title: "내 자리 - B-12",
+                    subtitle: "채플 입장 시간 · 17:00 시작 · 입구 좌측으로 입장",
+                    time: "5분 전",
+                    badge: nil,
+                    category: .classNotice,
+                    isRead: false
+                ),
+                NotificationItem(
+                    title: "데이터베이스 과제 마감 D-1",
+                    subtitle: "오늘 자정 마감 · 아직 제출 전이에요",
+                    time: "1시간 전",
+                    badge: .urgent("D-1"),
+                    category: .classNotice,
+                    isRead: false
+                ),
+                NotificationItem(
+                    title: "수강신청 알림",
+                    subtitle: "2025-2학기 수강신청이 D-2 남았어요",
+                    time: "2시간 전",
+                    badge: nil,
+                    category: .academic,
+                    isRead: false
+                )
+            ]
+        ),
+        NotificationSection(
+            title: "이번 주",
+            notifications: [
+                NotificationItem(
+                    title: "비전채플 11회차",
+                    subtitle: "내 자리 B-12",
+                    time: "5/8 17:00",
+                    badge: .neutral("내일"),
+                    category: .classNotice,
+                    isRead: false
+                ),
+                NotificationItem(
+                    title: "데이터베이스 중간고사",
+                    subtitle: "형남공학관 308호",
+                    time: "5/20",
+                    badge: .neutral("D-5"),
+                    category: .classNotice,
+                    isRead: false
+                ),
+                NotificationItem(
+                    title: "운영체제 과제 2 안내",
+                    subtitle: "5월 12일 마감",
+                    time: "5/6",
+                    badge: nil,
+                    category: .classNotice,
+                    isRead: false
+                ),
+                NotificationItem(
+                    title: "학과 사무실 안내",
+                    subtitle: "휴학 신청 마감 D-7",
+                    time: "5/5",
+                    badge: nil,
+                    category: .academic,
+                    isRead: false
+                ),
+                NotificationItem(
+                    title: "성적장학금 신청 안내",
+                    subtitle: "신청 기간 시작",
+                    time: "5/4",
+                    badge: nil,
+                    category: .academic,
+                    isRead: false
+                )
+            ]
+        ),
+        NotificationSection(
+            title: "이전",
+            notifications: [
+                NotificationItem(
+                    title: "3월 학사일정 안내",
+                    subtitle: nil,
+                    time: "3일 전",
+                    badge: nil,
+                    category: .academic,
+                    isRead: true
+                ),
+                NotificationItem(
+                    title: "전산 시스템 점검 안내",
+                    subtitle: nil,
+                    time: "4월 25일",
+                    badge: nil,
+                    category: .academic,
+                    isRead: true
+                )
+            ]
+        )
+    ]
+}
+
+#Preview {
+    NotificationView()
+}

--- a/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
@@ -18,6 +18,7 @@ struct SettingReducer {
         @Presents var alert: AlertState<Action.Alert>?
 
         var appVersion: String = "-"
+        var showsLogoutDialog = false
     }
 
     enum Action: BindableAction {
@@ -25,9 +26,11 @@ struct SettingReducer {
         case onAppear
         case backButtonTapped
         case logoutButtonTapped
+        case logoutCancelTapped
         case logoutConfirmed
         case logoutCompleted
         case togglePushAuthorization(Bool)
+        case syncPushAuthorizationResponse(Result<Bool, Error>)
         case pushAuthorizationResponse(Result<Bool, Error>)
         case requestPushAuthorizationResponse(Result<Bool, Error>)
         case termsOfServiceButtonTapped
@@ -60,23 +63,15 @@ struct SettingReducer {
                     await dismiss()
                 }
             case .logoutButtonTapped:
-                state.alert = AlertState {
-                    TextState(TextLiteral.SettingReducer.logoutAlertTitle)
-                } actions: {
-                    ButtonState(
-                        role: .destructive,
-                        action: .confirmLogoutTapped) {
-                            TextState(TextLiteral.SettingReducer.logoutAlertConfirmTitle)
-                        }
-                    ButtonState(
-                        role: .cancel) {
-                            TextState(TextLiteral.SettingReducer.alertCancelTitle)
-                        }
-                }
+                state.showsLogoutDialog = true
+                return .none
+            case .logoutCancelTapped:
+                state.showsLogoutDialog = false
                 return .none
             case .alert(.presented(.confirmLogoutTapped)):
                 return .send(.logoutConfirmed)
             case .logoutConfirmed:
+                state.showsLogoutDialog = false
                 return .run { send in
                     try await gradeClient.deleteTotalReportCard()
                     try await gradeClient.deleteAllSemesterGrades()
@@ -96,6 +91,12 @@ struct SettingReducer {
             case .togglePushAuthorization(false):
                 state.$permission.withLock { $0 = false }
                 YDSToast(TextLiteral.SettingReducer.pushAuthorizationDeniedToast, haptic: .success)
+                return .none
+            case .syncPushAuthorizationResponse(.success(let granted)):
+                state.$permission.withLock { $0 = granted }
+                return .none
+            case .syncPushAuthorizationResponse(.failure(let error)):
+                debugPrint("Setting Reducer: SyncPushAuthorization Error - \(error)")
                 return .none
             case .pushAuthorizationResponse(.success(let granted)):
                 state.$permission.withLock { $0 = granted }

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -12,6 +12,7 @@ import YDS_SwiftUI
 
 struct SettingView: View {
     @Bindable var store: StoreOf<SettingReducer>
+    @State private var showsNotificationSettings = false
     
     var body: some View {
         VStack(spacing: 0) {
@@ -20,16 +21,15 @@ struct SettingView: View {
                 .foregroundStyle(.gray950)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 6.5)
-            
+
             SettingList(
-                isPushAuthorizationEnabled: $store.permission,
                 appVersion: store.appVersion
             ) { tappedItem in
                 switch tappedItem {
                 case .logout:
                     store.send(.logoutButtonTapped)
-                case .toggleAuthorization(let granted):
-                    store.send(.togglePushAuthorization(granted))
+                case .notificationSettings:
+                    showsNotificationSettings = true
                 case .termsOfService:
                     store.send(.termsOfServiceButtonTapped)
                 case .privacyPolicy:
@@ -41,14 +41,17 @@ struct SettingView: View {
         .alert(
             $store.scope(state: \.alert, action: \.alert)
         )
+        .fullScreenCover(isPresented: $showsNotificationSettings) {
+            NotificationSettingsContainerView {
+                showsNotificationSettings = false
+            }
+        }
         .onAppear {
             store.send(.onAppear)
         }
     }
     
     struct SettingList: View {
-        @Binding var isPushAuthorizationEnabled: Bool
-        
         let appVersion: String
         let listItemTapped: (listItem) -> Void
         
@@ -71,12 +74,10 @@ struct SettingView: View {
                 ListRowView(
                     title: TextLiteral.SettingView.notificationSectionTitle,
                     items: [
-                        RowView(text: TextLiteral.SettingView.gradeNotificationTitle,
-                                rightItem: .toggle(
-                                    isPushAuthorizationEnabled: $isPushAuthorizationEnabled
-                                ),
+                        RowView(text: TextLiteral.SettingView.notificationSettingsTitle,
+                                rightItem: .none,
                                 action: {
-                                    listItemTapped(.toggleAuthorization(isPushAuthorizationEnabled))
+                                    listItemTapped(.notificationSettings)
                                 }
                                )
                     ])
@@ -119,9 +120,66 @@ struct SettingView: View {
     }
 }
 
+struct LogoutDialogView: View {
+    let cancel: () -> Void
+    let confirm: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.35)
+                .ignoresSafeArea()
+                .onTapGesture(perform: cancel)
+
+            VStack(spacing: 26) {
+                VStack(spacing: 9) {
+                    Text(TextLiteral.SettingReducer.logoutAlertTitle)
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(.gray950)
+
+                    Text(TextLiteral.SettingReducer.logoutAlertMessage)
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.slate500)
+                        .multilineTextAlignment(.center)
+                        .lineSpacing(3)
+                }
+
+                HStack(spacing: 12) {
+                    Button(action: cancel) {
+                        Text(TextLiteral.SettingReducer.alertCancelTitle)
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(.gray950)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .background(.gray25)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: confirm) {
+                        Text(TextLiteral.SettingReducer.logoutAlertConfirmTitle)
+                            .font(.system(size: 15, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .background(.blue600)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.top, 40)
+            .padding(.horizontal, 34)
+            .padding(.bottom, 28)
+            .background(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 18))
+            .padding(.horizontal, 34)
+        }
+    }
+}
+
 enum listItem {
     case logout
-    case toggleAuthorization(Bool)
+    case notificationSettings
     case termsOfService
     case privacyPolicy
 }

--- a/Soomsil-USaint/Application/Rusaint_iOSApp.swift
+++ b/Soomsil-USaint/Application/Rusaint_iOSApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import BackgroundTasks
+import UserNotifications
 
 import ComposableArchitecture
 import FirebaseCore
@@ -16,12 +17,129 @@ import Mixpanel
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
+        UNUserNotificationCenter.current().delegate = self
+        registerNotificationCategories()
         if let token = Bundle.main.object(forInfoDictionaryKey: "MIXPANEL_TEAM_TOKEN") as? String {
             Mixpanel.initialize(token: "4cb8a3b1aabf9715a4db3005904a744d", trackAutomaticEvents: false)
         } else {
             assertionFailure("Mixpanel 토큰을 불러올 수 없습니다.")
         }
         return true
+    }
+
+    private func registerNotificationCategories() {
+        let chapelCategory = UNNotificationCategory(
+            identifier: USaintNotificationCategory.chapel.rawValue,
+            actions: [
+                UNNotificationAction(
+                    identifier: NotificationActionIdentifier.openChapelSeat,
+                    title: "내 자리 보기",
+                    options: [.foreground]
+                ),
+                UNNotificationAction(
+                    identifier: NotificationActionIdentifier.snoozeChapel,
+                    title: "15분 후 다시 알림",
+                    options: []
+                )
+            ],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        let assignmentCategory = UNNotificationCategory(
+            identifier: USaintNotificationCategory.assignmentDeadline.rawValue,
+            actions: [
+                UNNotificationAction(
+                    identifier: NotificationActionIdentifier.openAssignment,
+                    title: "과제 자세히 보기",
+                    options: [.foreground]
+                ),
+                UNNotificationAction(
+                    identifier: NotificationActionIdentifier.snoozeAssignment,
+                    title: "내일 다시 알림 받기",
+                    options: []
+                )
+            ],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        let gradeCategory = UNNotificationCategory(
+            identifier: USaintNotificationCategory.gradeAnnouncement.rawValue,
+            actions: [
+                UNNotificationAction(
+                    identifier: NotificationActionIdentifier.openGrade,
+                    title: "성적표 자세히 보기",
+                    options: [.foreground]
+                )
+            ],
+            intentIdentifiers: [],
+            options: []
+        )
+
+        UNUserNotificationCenter.current().setNotificationCategories([
+            chapelCategory,
+            assignmentCategory,
+            gradeCategory
+        ])
+    }
+}
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        [.banner, .list, .sound]
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        switch response.actionIdentifier {
+        case NotificationActionIdentifier.snoozeChapel:
+            await scheduleSnoozedNotification(from: response, seconds: 15 * 60)
+            return
+        case NotificationActionIdentifier.snoozeAssignment:
+            await scheduleSnoozedNotification(from: response, seconds: 24 * 60 * 60)
+            return
+        default:
+            break
+        }
+
+        if let route = response.notification.request.content.userInfo[NotificationUserInfoKey.route] as? String {
+            UserDefaults.standard.set(route, forKey: NotificationStorageKey.pendingRoute)
+        }
+
+        NotificationCenter.default.post(
+            name: .usaintNotificationOpened,
+            object: nil,
+            userInfo: response.notification.request.content.userInfo
+        )
+    }
+
+    private func scheduleSnoozedNotification(
+        from response: UNNotificationResponse,
+        seconds: TimeInterval
+    ) async {
+        let originalContent = response.notification.request.content
+        let content = UNMutableNotificationContent()
+        content.title = originalContent.userInfo[NotificationUserInfoKey.title] as? String ?? originalContent.title
+        content.body = originalContent.userInfo[NotificationUserInfoKey.body] as? String ?? originalContent.body
+        content.sound = .default
+        content.categoryIdentifier = originalContent.categoryIdentifier
+        content.threadIdentifier = originalContent.threadIdentifier
+        content.userInfo = originalContent.userInfo
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: seconds, repeats: false)
+        let request = UNNotificationRequest(
+            identifier: "\(response.notification.request.identifier)-snooze-\(Int(Date().timeIntervalSince1970))",
+            content: content,
+            trigger: trigger
+        )
+
+        try? await UNUserNotificationCenter.current().add(request)
     }
 }
 

--- a/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
@@ -5,14 +5,109 @@
 //  Created by 이조은 on 1/6/25.
 //
 
-import UIKit
+import Foundation
+import UserNotifications
 
 import ComposableArchitecture
+
+enum USaintNotificationCategory: String, Sendable {
+    case courseRegistration
+    case assignmentDeadline
+    case gradeAnnouncement
+    case chapel
+    case marketing
+
+    var userDefaultsKey: String {
+        switch self {
+        case .courseRegistration:
+            "courseRegistrationNotificationEnabled"
+        case .assignmentDeadline:
+            "assignmentDeadlineNotificationEnabled"
+        case .gradeAnnouncement:
+            "gradeAnnouncementNotificationEnabled"
+        case .chapel:
+            "chapelNotificationEnabled"
+        case .marketing:
+            "marketingNotificationEnabled"
+        }
+    }
+
+    var defaultEnabled: Bool {
+        switch self {
+        case .marketing:
+            false
+        case .courseRegistration, .assignmentDeadline, .gradeAnnouncement, .chapel:
+            true
+        }
+    }
+}
+
+enum USaintNotificationRoute: String, Sendable {
+    case notification
+    case chapel
+}
+
+struct USaintNotificationPayload: Sendable {
+    let identifier: String
+    let title: String
+    let body: String
+    let category: USaintNotificationCategory
+    let route: USaintNotificationRoute
+    let timeInterval: TimeInterval
+
+    static func gradeAnnouncement(lectureTitle: String) -> Self {
+        Self(
+            identifier: "grade-\(lectureTitle)",
+            title: "\(lectureTitle) 성적 공개",
+            body: "성적이 공개되었어요",
+            category: .gradeAnnouncement,
+            route: .notification,
+            timeInterval: 2
+        )
+    }
+
+    static func chapelEntrance(chapelCard: ChapelCard) -> Self {
+        Self(
+            identifier: "chapel-\(chapelCard.seatPosition)",
+            title: "내 자리 - \(chapelCard.seatPosition)",
+            body: "채플 입장 시간 · 17:00 시작 · 입구 좌측으로 입장",
+            category: .chapel,
+            route: .chapel,
+            timeInterval: 2
+        )
+    }
+
+    static func courseRegistration(daysRemaining: Int) -> Self {
+        Self(
+            identifier: "course-registration-d-\(daysRemaining)",
+            title: "수강신청 알림",
+            body: "2025-2학기 수강신청이 D-\(daysRemaining) 남았어요",
+            category: .courseRegistration,
+            route: .notification,
+            timeInterval: 2
+        )
+    }
+
+    static func assignmentDeadline(title: String, daysRemaining: Int) -> Self {
+        Self(
+            identifier: "assignment-\(title)-d-\(daysRemaining)",
+            title: "\(title) 과제 마감 D-\(daysRemaining)",
+            body: "오늘 자정 마감 · 아직 제출 전이에요",
+            category: .assignmentDeadline,
+            route: .notification,
+            timeInterval: 2
+        )
+    }
+}
 
 struct LocalNotificationClient {
     var requestPushAuthorization: @Sendable () async throws -> Bool
     var getPushAuthorizationStatus: @Sendable () async -> Bool
+    var scheduleNotification: @Sendable (USaintNotificationPayload) async throws -> Void
     var setLecturePushNotification: @Sendable (String) async throws -> Void
+    var setChapelPushNotification: @Sendable (ChapelCard) async throws -> Void
+    var setCourseRegistrationPushNotification: @Sendable (Int) async throws -> Void
+    var setAssignmentDeadlinePushNotification: @Sendable (String, Int) async throws -> Void
 }
 
 extension DependencyValues {
@@ -30,16 +125,16 @@ extension LocalNotificationClient: DependencyKey {
         }, getPushAuthorizationStatus: {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             return (settings.authorizationStatus == .authorized) || (settings.authorizationStatus == .provisional)
+        }, scheduleNotification: { payload in
+            try await scheduleLocalNotification(payload)
         }, setLecturePushNotification: { lectureTitle in
-            let content = UNMutableNotificationContent()
-            content.title = "숨쉴때 유세인트"
-            content.body = "[\(lectureTitle)] 과목의 성적이 공개되었어요."
-            content.sound = .default
-            
-            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 2, repeats: false)
-            let request = UNNotificationRequest(identifier: lectureTitle, content: content, trigger: trigger)
-            
-            try await UNUserNotificationCenter.current().add(request)
+            try await scheduleLocalNotification(.gradeAnnouncement(lectureTitle: lectureTitle))
+        }, setChapelPushNotification: { chapelCard in
+            try await scheduleLocalNotification(.chapelEntrance(chapelCard: chapelCard))
+        }, setCourseRegistrationPushNotification: { daysRemaining in
+            try await scheduleLocalNotification(.courseRegistration(daysRemaining: daysRemaining))
+        }, setAssignmentDeadlinePushNotification: { title, daysRemaining in
+            try await scheduleLocalNotification(.assignmentDeadline(title: title, daysRemaining: daysRemaining))
         }
     )
     
@@ -48,10 +143,67 @@ extension LocalNotificationClient: DependencyKey {
             return true
         }, getPushAuthorizationStatus: {
             return true
+        }, scheduleNotification: { payload in
+            debugPrint(payload)
         }, setLecturePushNotification: { lectureTitle in
             debugPrint(lectureTitle)
+        }, setChapelPushNotification: { chapelCard in
+            debugPrint(chapelCard)
+        }, setCourseRegistrationPushNotification: { daysRemaining in
+            debugPrint(daysRemaining)
+        }, setAssignmentDeadlinePushNotification: { title, daysRemaining in
+            debugPrint(title, daysRemaining)
         }
     )
     
     static let testValue: LocalNotificationClient = previewValue
+}
+
+private func isPushEnabled() -> Bool {
+    if UserDefaults.standard.object(forKey: "permission") == nil {
+        return true
+    }
+    return UserDefaults.standard.bool(forKey: "permission")
+}
+
+private func isCategoryEnabled(_ category: USaintNotificationCategory) -> Bool {
+    if UserDefaults.standard.object(forKey: category.userDefaultsKey) == nil {
+        return category.defaultEnabled
+    }
+    return UserDefaults.standard.bool(forKey: category.userDefaultsKey)
+}
+
+private func scheduleLocalNotification(_ payload: USaintNotificationPayload) async throws {
+    let settings = await UNUserNotificationCenter.current().notificationSettings()
+
+    guard (settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional),
+          isPushEnabled(),
+          isCategoryEnabled(payload.category) else {
+        return
+    }
+
+    let content = UNMutableNotificationContent()
+    content.title = payload.title
+    content.body = payload.body
+    content.sound = .default
+    content.categoryIdentifier = payload.category.rawValue
+    content.threadIdentifier = payload.category.rawValue
+    content.userInfo = [
+        NotificationUserInfoKey.category: payload.category.rawValue,
+        NotificationUserInfoKey.route: payload.route.rawValue,
+        NotificationUserInfoKey.title: payload.title,
+        NotificationUserInfoKey.body: payload.body
+    ]
+
+    let trigger = UNTimeIntervalNotificationTrigger(
+        timeInterval: payload.timeInterval,
+        repeats: false
+    )
+    let request = UNNotificationRequest(
+        identifier: payload.identifier,
+        content: content,
+        trigger: trigger
+    )
+
+    try await UNUserNotificationCenter.current().add(request)
 }

--- a/Soomsil-USaint/Global/Utils/NotificationRouting.swift
+++ b/Soomsil-USaint/Global/Utils/NotificationRouting.swift
@@ -1,0 +1,29 @@
+//
+//  NotificationRouting.swift
+//  Soomsil-USaint
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let usaintNotificationOpened = Notification.Name("usaintNotificationOpened")
+}
+
+enum NotificationUserInfoKey {
+    static let route = "route"
+    static let category = "category"
+    static let title = "title"
+    static let body = "body"
+}
+
+enum NotificationStorageKey {
+    static let pendingRoute = "pendingNotificationRoute"
+}
+
+enum NotificationActionIdentifier {
+    static let openChapelSeat = "OPEN_CHAPEL_SEAT"
+    static let snoozeChapel = "SNOOZE_CHAPEL"
+    static let openAssignment = "OPEN_ASSIGNMENT"
+    static let snoozeAssignment = "SNOOZE_ASSIGNMENT"
+    static let openGrade = "OPEN_GRADE"
+}

--- a/Soomsil-USaint/Global/Utils/TextLiteral.swift
+++ b/Soomsil-USaint/Global/Utils/TextLiteral.swift
@@ -32,6 +32,7 @@ enum TextLiteral {
         static let logoutButtonTitle = "로그아웃"
         static let notificationSectionTitle = "알림"
         static let gradeNotificationTitle = "성적 알림 받기"
+        static let notificationSettingsTitle = "알림 설정"
         static let termsSectionTitle = "약관"
         static let termsOfServiceTitle = "이용약관"
         static let privacyPolicyTitle = "개인정보수집 및 허용"
@@ -45,7 +46,8 @@ enum TextLiteral {
     // MARK: - SettingReducer
 
     enum SettingReducer {
-        static let logoutAlertTitle = "로그아웃 하시겠습니까?"
+        static let logoutAlertTitle = "정말 로그아웃할까요?"
+        static let logoutAlertMessage = "다시 로그인하려면\n학번을 입력해야 해요"
         static let logoutAlertConfirmTitle = "로그아웃"
         static let alertCancelTitle = "취소"
         static let logoutSuccessToast = "로그아웃 완료"
@@ -284,6 +286,47 @@ enum TextLiteral {
     enum MainTabView {
         static let chapelPlaceholder = "채플 화면"
         static let notificationPlaceholder = "알림 화면"
+    }
+
+    // MARK: - NotificationView
+
+    enum NotificationView {
+        static let title = "알림"
+        static let unreadTitle = "읽지 않은 알림"
+        static let countUnit = "건"
+        static let markAllReadButtonTitle = "모두 읽음"
+        static let unreadDescription = "확인할 알림이 많이 쌓였어요"
+        static let featuredTitle = "이번 학기 수강신청 안내"
+        static let featuredSubtitle = "지금 확인해야 하는 안내가 있어요"
+        static let allTabTitle = "전체"
+        static let academicTabTitle = "학사"
+        static let classTabTitle = "수업"
+        static let retentionNotice = "중요 알림은 14일 동안 보관돼요"
+    }
+
+    // MARK: - NotificationSettingsView
+
+    enum NotificationSettingsView {
+        static let title = "알림 설정"
+        static let receiveSectionTitle = "알림 받기"
+        static let pushNotificationTitle = "푸시 알림"
+        static let pushNotificationSubtitle = "알림으로 소식 받기"
+        static let pushNotificationDeniedSubtitle = "iPhone 설정에서 알림을 켜주세요"
+        static let typeSectionTitle = "알림 종류"
+        static let courseRegistrationTitle = "수강신청"
+        static let courseRegistrationSubtitle = "수강신청 일정 알림"
+        static let assignmentDeadlineTitle = "과제 마감"
+        static let assignmentDeadlineSubtitle = "마감 24시간 전 알림"
+        static let gradeAnnouncementTitle = "성적 발표"
+        static let gradeAnnouncementSubtitle = "성적 공개 즉시 알림"
+        static let chapelTitle = "채플 안내"
+        static let chapelSubtitle = "채플 일정 알림"
+        static let marketingSectionTitle = "마케팅"
+        static let marketingNotificationTitle = "마케팅 알림"
+        static let marketingNotificationSubtitle = "이벤트 · 혜택 알림"
+        static let debugSectionTitle = "DEBUG"
+        static let debugSendTestNotificationTitle = "테스트 알림 보내기"
+        static let debugSendTestNotificationSubtitle = "현재 기기에만 2초 뒤 테스트 알림이 예약돼요"
     }
 
     // MARK: - StudentInfoView

--- a/Soomsil-USaint/Resource/Assets.xcassets/Icons/ic_alarm_setting.imageset/Contents.json
+++ b/Soomsil-USaint/Resource/Assets.xcassets/Icons/ic_alarm_setting.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "ic_alarm_setting.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Soomsil-USaint/Resource/Assets.xcassets/Icons/ic_alarm_setting.imageset/ic_alarm_setting.svg
+++ b/Soomsil-USaint/Resource/Assets.xcassets/Icons/ic_alarm_setting.imageset/ic_alarm_setting.svg
@@ -1,0 +1,11 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19.2499 3.66699H12.8333" stroke="#9CA3AF" stroke-width="1.83333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.16667 3.66699H2.75" stroke="#9CA3AF" stroke-width="1.83333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.25 11H11" stroke="#9CA3AF" stroke-width="1.83333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.33333 11H2.75" stroke="#9CA3AF" stroke-width="1.83333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19.2501 18.333H14.6667" stroke="#9CA3AF" stroke-width="1.83333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M11 18.333H2.75" stroke="#9CA3AF" stroke-width="1.83333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.8333 1.83301V5.49967" stroke="#9CA3AF" stroke-width="1.83333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.33325 9.16699V12.8337" stroke="#9CA3AF" stroke-width="1.83333" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14.6667 16.5V20.1667" stroke="#9CA3AF" stroke-width="1.83333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Soomsil-USaint/Resource/IconLiteral.swift
+++ b/Soomsil-USaint/Resource/IconLiteral.swift
@@ -35,6 +35,7 @@ public enum Icon {
     public static var sofa: Image { .load(name: "ic_sofa") }
     public static var bell: Image { .load(name: "ic_bell") }
     public static var person: Image { .load(name: "ic_person") }
+    public static var alarmSetting: Image { .load(name: "ic_alarm_setting") }
     public static var info: Image { .load(name: "ic_info") }
     public static var qr: Image { .load(name: "ic_qr") }
 
@@ -48,4 +49,3 @@ extension Image {
         return Image(name)
     }
 }
-


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
Group D 푸시 알림 작업을 진행했습니다.
알림 탭 화면과 알림 설정 화면을 추가하고, iOS 시스템 알림 권한 요청 및 로컬 알림 라우팅을 연결했습니다.
마이페이지 설정에서는 알림 설정 화면으로 진입할 수 있도록 변경했고, 로그아웃 모달 디자인과 채플 페이지 버튼 제거도 함께 반영했습니다.


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- 이슈 티켓 : #169 
- 피그마 :  https://www.figma.com/design/uInyEpaWQfH4A4IORIl7rx/tf-Usaint?node-id=2448-383&t=EFgefO1tJqD2piSR-1
- 관련 문서 :
- close: #169 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
### 작업 내용
  - 알림 탭 화면 추가
      - 기존 알림 탭 placeholder를 실제 NotificationView로 교체
      - 읽지 않은 알림 요약, 카테고리 탭, 알림 리스트 UI 구성
      - 알림 설정 아이콘으로 설정 화면 진입 연결
      - ic_alarm_setting.svg 에셋 추가 및 Icon.alarmSetting 연결

  - 알림 설정 화면 추가
      - 푸시 알림 ON/OFF
      - 수강신청, 과제 마감, 성적 발표, 채플 안내, 마케팅 알림 토글 구성
      - iOS 시스템 알림 권한이 꺼져 있는 경우 앱 내에서 직접 변경하지 않고
        iPhone 설정 화면으로 이동하도록 처리

      - 앱 내부에서 제어할 수 없는 진동 설정 등은 제외
      - Debug 환경에서 현재 기기에만 테스트 로컬 알림을 예약할 수 있는 버튼 추가

  - iOS 알림 권한 및 로컬 알림 처리
      - 앱 최초 실행 시 시스템 알림 권한 요청 처리
      - 실제 시스템 알림 권한 상태를 기준으로 앱 내부 permission 상태 동기화
      - 권한이 허용된 경우에만 로컬 알림 예약
      - 앱 내부 전체 푸시 설정 및 알림 종류별 토글 값을 기준으로 알림 예약 여부
        결정

  - 알림 라우팅 연결
      - 알림 payload에 route/category/title/body 정보 추가
      - 알림을 눌렀을 때 앱 내부 탭으로 이동하도록 연결
      - 채플 알림은 채플 탭으로 이동
      - 그 외 알림은 알림 탭으로 이동
      - 앱이 종료된 상태에서 알림을 눌러 실행되는 경우에도 pending route를 저장
        한 뒤 로그인/초기화 완료 후 라우팅 처리

  - 확장 알림 액션 추가
      - iOS 기본 확장 알림 액션으로 버튼 제공
      - 채플 알림: 내 자리 보기, 15분 후 다시 알림
      - 과제 알림: 과제 자세히 보기, 내일 다시 알림 받기
      - 성적 알림: 성적표 자세히 보기
      - 다시 알림 액션 선택 시 기존 알림 정보를 유지해 재예약

  - 마이페이지 설정 개선
      - 기존 알림 토글 행을 알림 설정 진입 행으로 변경
      - 알림 설정 화면을 full screen cover로 연결
      - 기존 시스템 Alert 로그아웃 확인창을 커스텀 로그아웃 모달로 변경
      - 모달 배경 dim 처리 및 탭바까지 함께 덮이도록 MainTabView 레벨에서 표시

  - 채플 페이지 수정
      - 채플 페이지 하단 출석 인증하기 버튼 제거


### 세부 내용
- iOS 알림 권한은 앱 내부 커스텀 팝업으로 대체할 수 없어서 시스템 권한 팝업만
    사용하도록 정리했습니다.

  - 사용자가 이미 알림 권한을 거부한 경우 앱에서 직접 권한을 다시 켤 수 없기 때
    문에 UIApplication.openSettingsURLString으로 iPhone 설정 화면을 열도록 처리
    했습니다.

  - 진동 설정처럼 앱 내부에서 직접 제어할 수 없는 항목은 알림 설정 화면에서 제외
    했습니다.

  - 알림 토글은 실제 예약 시점에도 다시 확인하도록 했습니다.
      - 시스템 알림 권한
      - 앱 내부 전체 푸시 설정
      - 알림 종류별 설정

  - 앱이 종료된 상태에서 알림을 눌러 들어오는 경우를 고려해 route를 UserDefaults
    에 잠시 저장하고, 앱 초기화 이후 라우팅되도록 처리했습니다.

  - 피그마의 확장 알림 배너처럼 완전히 커스텀된 알림 UI는 별도 Notification
    Content Extension target이 필요합니다. 이번 작업에서는 앱 본체에서 바로 적용
    가능한 iOS 기본 확장 알림 액션을 구현했습니다.

  - 테스트 알림은 서버 푸시가 아니라 로컬 알림이므로 현재 기기에서만 발생합니다.


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
- Apple UserNotifications
      - UNUserNotificationCenter
      - UNNotificationCategory
      - UNNotificationAction
      - UIApplication.openSettingsURLString


## 🔥 Test
<!-- Test -->

https://github.com/user-attachments/assets/772773bf-60ab-4103-9ae1-3b25e274a902

