### PR TITLE
[#171] 다크모드 및 설정/로그인 화면 개선

### DIFF
--- a/Soomsil-USaint/Application/Feature/Chapel/Chapel/View/ChapelView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/Chapel/View/ChapelView.swift
@@ -50,7 +50,7 @@ struct ChapelView: View {
 
                 Spacer(minLength: 0)
             }
-            .background(.white)
+            .background(Color.adaptiveBackground)
             .toolbar(.hidden, for: .navigationBar)
         } destination: { store in
             switch store.case {
@@ -68,7 +68,7 @@ private extension ChapelView {
         HStack(alignment: .center) {
             Text(TextLiteral.ChapelView.title)
                 .font(.system(size: 18, weight: .bold))
-                .foregroundStyle(.gray950)
+                .foregroundStyle(Color.adaptivePrimaryText)
 
             Spacer()
 

--- a/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatLocationView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatLocationView.swift
@@ -39,7 +39,7 @@ struct ChapelSeatLocationView: View {
                 .padding(.top, 16)
             }
         }
-        .background(.white)
+        .background(Color.adaptiveBackground)
         .navigationTitle(TextLiteral.ChapelSeatLocationView.title)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden()
@@ -52,7 +52,7 @@ struct ChapelSeatLocationView: View {
                         .renderingMode(.template)
                         .resizable()
                         .frame(width: 24, height: 24)
-                        .foregroundStyle(.navy900)
+                        .foregroundStyle(Color.adaptivePrimaryText)
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
@@ -61,7 +61,7 @@ struct ChapelSeatLocationView: View {
                 } label: {
                     Icon.info
                         .renderingMode(.template)
-                        .foregroundStyle(.navy900)
+                        .foregroundStyle(Color.adaptivePrimaryText)
                         .frame(width: 22, height: 22)
                 }
                 .accessibilityLabel(TextLiteral.ChapelSeatLocationView.title)

--- a/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatMapView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/SeatLocation/View/ChapelSeatMapView.swift
@@ -97,11 +97,11 @@ struct ZoomableChapelSeatMapView: View {
         .padding(.vertical, 18)
         .padding(.horizontal, 24)
         .frame(maxWidth: .infinity)
-        .background(.gray25)
+        .background(Color.adaptiveSurface)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
         .onTapGesture(count: 2) {
             withAnimation(.easeInOut(duration: 0.2)) {
@@ -159,7 +159,7 @@ struct ChapelSeatMapView: View {
                 .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .frame(height: 58)
-                .background(.gray800)
+                .background(Color.adaptiveMutedSurface)
 
             VStack(spacing: 38) {
                 ForEach(zoneRows.indices, id: \.self) { rowIndex in
@@ -176,7 +176,7 @@ struct ChapelSeatMapView: View {
         }
         .padding(.horizontal, 26)
         .padding(.vertical, 24)
-        .background(.gray25)
+        .background(Color.adaptiveSurface)
     }
 }
 
@@ -216,7 +216,7 @@ private struct ChapelSeatZoneView: View {
         VStack(spacing: 16) {
             Text(zone.id)
                 .font(.system(size: 15, weight: .bold))
-                .foregroundStyle(.gray800)
+                .foregroundStyle(Color.adaptiveSecondaryText)
 
             VStack(spacing: seatGap) {
                 ForEach(zone.rows.indices, id: \.self) { rowIndex in

--- a/Soomsil-USaint/Application/Feature/Chapel/View/ChapelSeatInfoView.swift
+++ b/Soomsil-USaint/Application/Feature/Chapel/View/ChapelSeatInfoView.swift
@@ -73,7 +73,7 @@ struct ChapelSeatInfoView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(TextLiteral.ChapelSeatInfoView.title)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.slate600)
+                .foregroundStyle(Color.adaptiveSecondaryText)
 
             Text(seatPosition)
                 .font(.system(size: 32, weight: .black))
@@ -81,16 +81,16 @@ struct ChapelSeatInfoView: View {
 
             Text(seatDescription)
                 .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.slate600)
+                .foregroundStyle(Color.adaptiveSecondaryText)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 20)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.white)
+        .background(Color.adaptiveSurface)
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
     }
 

--- a/Soomsil-USaint/Application/Feature/Component/ChapelAttendanceInfoView.swift
+++ b/Soomsil-USaint/Application/Feature/Component/ChapelAttendanceInfoView.swift
@@ -90,7 +90,7 @@ struct ChapelAttendanceInfoView: View {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Text(title)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(.gray950)
+                    .foregroundStyle(Color.adaptivePrimaryText)
 
                 Spacer()
 
@@ -113,7 +113,7 @@ struct ChapelAttendanceInfoView: View {
             .progressViewStyle(
                 LinearProgressViewStyle(
                     progressColor: .blue500,
-                    trackColor: .slate100,
+                    trackColor: Color.adaptiveMutedSurface,
                     height: 8
                 )
             )
@@ -129,11 +129,11 @@ struct ChapelAttendanceInfoView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 18)
         .frame(maxWidth: .infinity)
-        .background(.white)
+        .background(Color.adaptiveSurface)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
     }
 
@@ -143,7 +143,7 @@ struct ChapelAttendanceInfoView: View {
                 VStack(alignment: .leading, spacing: 3) {
                     Text(title)
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.gray950)
+                        .foregroundStyle(Color.adaptivePrimaryText)
 
                     Text(
                         TextLiteral.ChapelAttendanceInfoView.attendanceSummary(
@@ -171,7 +171,7 @@ struct ChapelAttendanceInfoView: View {
             .progressViewStyle(
                 LinearProgressViewStyle(
                     progressColor: .blue500,
-                    trackColor: .slate100,
+                    trackColor: Color.adaptiveMutedSurface,
                     height: 8
                 )
             )
@@ -179,11 +179,11 @@ struct ChapelAttendanceInfoView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 16.5)
         .frame(maxWidth: .infinity)
-        .background(.white)
+        .background(Color.adaptiveSurface)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
     }
 
@@ -192,11 +192,11 @@ struct ChapelAttendanceInfoView: View {
             .font(.system(size: 16, weight: .bold))
             .foregroundStyle(.blue500)
             .frame(maxWidth: .infinity, minHeight: 80)
-            .background(.buttonSurface)
+            .background(Color.adaptiveSurface)
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             .overlay(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(.slate100, lineWidth: 1)
+                    .stroke(Color.adaptiveBorder, lineWidth: 1)
             )
     }
 }

--- a/Soomsil-USaint/Application/Feature/Component/Color.swift
+++ b/Soomsil-USaint/Application/Feature/Component/Color.swift
@@ -5,4 +5,25 @@
 //  Created by 이조은 on 1/6/25.
 //
 
-import Foundation
+import SwiftUI
+
+extension Color {
+    static let adaptiveBackground = adaptive(light: .white, dark: assetColor("gray_950"))
+    static let adaptiveSurface = adaptive(light: .white, dark: assetColor("gray_900"))
+    static let adaptiveMutedSurface = adaptive(light: assetColor("gray_25"), dark: assetColor("gray_800").withAlphaComponent(0.36))
+    static let adaptiveBorder = adaptive(light: assetColor("slate_100"), dark: assetColor("gray_800").withAlphaComponent(0.45))
+    static let adaptivePrimaryText = adaptive(light: assetColor("gray_950"), dark: .white)
+    static let adaptiveSecondaryText = adaptive(light: assetColor("gray_500"), dark: assetColor("gray_500"))
+    static let adaptiveTertiaryText = adaptive(light: assetColor("slate_500"), dark: assetColor("slate_500"))
+    static let adaptiveSelectedPill = adaptive(light: assetColor("gray_950"), dark: assetColor("blue_600"))
+
+    private static func adaptive(light: UIColor, dark: UIColor) -> Color {
+        Color(UIColor { traitCollection in
+            traitCollection.userInterfaceStyle == .dark ? dark : light
+        })
+    }
+
+    private static func assetColor(_ name: String) -> UIColor {
+        UIColor(named: name) ?? .clear
+    }
+}

--- a/Soomsil-USaint/Application/Feature/Component/Color.swift
+++ b/Soomsil-USaint/Application/Feature/Component/Color.swift
@@ -11,6 +11,7 @@ extension Color {
     static let adaptiveBackground = adaptive(light: .white, dark: assetColor("gray_950"))
     static let adaptiveSurface = adaptive(light: .white, dark: assetColor("gray_900"))
     static let adaptiveMutedSurface = adaptive(light: assetColor("gray_25"), dark: assetColor("gray_800").withAlphaComponent(0.36))
+    static let adaptiveInputSurface = adaptive(light: .white, dark: assetColor("gray_800").withAlphaComponent(0.52))
     static let adaptiveBorder = adaptive(light: assetColor("slate_100"), dark: assetColor("gray_800").withAlphaComponent(0.45))
     static let adaptivePrimaryText = adaptive(light: assetColor("gray_950"), dark: .white)
     static let adaptiveSecondaryText = adaptive(light: assetColor("gray_500"), dark: assetColor("gray_500"))

--- a/Soomsil-USaint/Application/Feature/Component/CustomTabBar.swift
+++ b/Soomsil-USaint/Application/Feature/Component/CustomTabBar.swift
@@ -42,11 +42,11 @@ struct CustomTabBar: View {
             }
         }
         .padding(6)
-        .background(Color.white)
+        .background(Color.adaptiveSurface)
         .clipShape(Capsule())
         .overlay(
             Capsule()
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
         .padding(.horizontal, 20)
         .padding(.top, 10)
@@ -63,7 +63,7 @@ struct CustomTabBar: View {
                     .renderingMode(.template)
                     .resizable()
                     .frame(width: 18, height: 18)
-                    .foregroundStyle(isSelected ? .white : .gray500)
+                    .foregroundStyle(isSelected ? .white : Color.adaptiveSecondaryText)
                 Text(tab.title)
                     .font(
                         .system(
@@ -71,7 +71,7 @@ struct CustomTabBar: View {
                             weight: isSelected ? .semibold : .medium
                         )
                     )
-                    .foregroundStyle(isSelected ? .white : .gray500)
+                    .foregroundStyle(isSelected ? .white : Color.adaptiveSecondaryText)
             }
             .frame(maxWidth: .infinity)
             .padding(.horizontal, 12)

--- a/Soomsil-USaint/Application/Feature/Component/GPAGraphView.swift
+++ b/Soomsil-USaint/Application/Feature/Component/GPAGraphView.swift
@@ -55,7 +55,7 @@ private extension GPAGraphView {
             HStack(alignment: .center) {
                 Text(TextLiteral.GPAGraphView.title)
                     .font(.system(size: 15, weight: .bold))
-                    .foregroundStyle(.navy700)
+                    .foregroundStyle(Color.adaptivePrimaryText)
 
                 Spacer()
 
@@ -96,11 +96,11 @@ private extension GPAGraphView {
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 20)
-        .background(.white)
+        .background(Color.adaptiveSurface)
         .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 20, style: .continuous)
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
     }
 
@@ -109,7 +109,7 @@ private extension GPAGraphView {
             HStack(alignment: .center) {
                 Text(TextLiteral.GPAGraphView.overallTrendTitle)
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(.gray850)
+                    .foregroundStyle(Color.adaptivePrimaryText)
 
                 Spacer()
 
@@ -127,11 +127,11 @@ private extension GPAGraphView {
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 18)
-        .background(.white)
+        .background(Color.adaptiveSurface)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
     }
 

--- a/Soomsil-USaint/Application/Feature/Component/GradeRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Component/GradeRowView.swift
@@ -59,10 +59,10 @@ private extension GradeRowView {
                 .fill(.orange500)
                 .frame(width: 8, height: 8)
 
-            TitleText(
-                title: title,
-                color: .navy700
-            )
+                TitleText(
+                    title: title,
+                    color: Color.adaptivePrimaryText
+                )
 
             CourseMetadataView(
                 professorName: sanitizedProfessorName,
@@ -81,11 +81,11 @@ private extension GradeRowView {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 16)
-        .background(.white)
+        .background(Color.adaptiveSurface)
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
     }
 
@@ -101,7 +101,7 @@ private extension GradeRowView {
             VStack(alignment: .leading, spacing: 4) {
                 TitleText(
                     title: title,
-                    color: .gray950
+                    color: Color.adaptivePrimaryText
                 )
 
                 CourseMetadataView(
@@ -122,7 +122,7 @@ private extension GradeRowView {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
-        .background(.gray150)
+        .background(Color.adaptiveSurface)
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 

--- a/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/HomeView.swift
@@ -55,7 +55,7 @@ struct HomeView: View {
                 .padding(.horizontal, 20)
                 .padding(.bottom, 110)
             }
-            .background(.white)
+            .background(Color.adaptiveBackground)
         } destination: { store in
             switch store.case {
             case .web(let store):
@@ -91,12 +91,12 @@ private extension HomeView {
         VStack(alignment: .leading, spacing: 2) {
             Text(TextLiteral.HomeView.greeting(store.studentInfo.name))
                 .font(.system(size: 20, weight: .bold))
-                .foregroundStyle(.gray850)
+                .foregroundStyle(Color.adaptivePrimaryText)
                 .lineLimit(1)
 
             Text(TextLiteral.HomeView.notificationSummary(count: 0))
                 .font(.system(size: 12, weight: .regular))
-                .foregroundStyle(.gray500)
+                .foregroundStyle(Color.adaptiveSecondaryText)
         }
     }
 }

--- a/Soomsil-USaint/Application/Feature/Home/View/StudentInfoView.swift
+++ b/Soomsil-USaint/Application/Feature/Home/View/StudentInfoView.swift
@@ -15,12 +15,12 @@ struct StudentInfoView: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(student.name)
                     .font(.system(size: 18, weight: .bold))
-                    .foregroundStyle(.gray950)
+                    .foregroundStyle(Color.adaptivePrimaryText)
                     .lineLimit(1)
 
                 Text(student.subtitle)
                     .font(.system(size: 12, weight: .regular))
-                    .foregroundStyle(.slate600)
+                    .foregroundStyle(Color.adaptiveSecondaryText)
                     .lineLimit(1)
             }
 
@@ -29,22 +29,22 @@ struct StudentInfoView: View {
             if let studentID = student.trimmedStudentID {
                 Text(TextLiteral.StudentInfoView.studentID(studentID))
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(.gray950)
+                    .foregroundStyle(Color.adaptivePrimaryText)
                     .lineLimit(1)
                     .padding(.horizontal, 15)
                     .padding(.vertical, 10)
-                    .background(.gray50)
+                    .background(Color.adaptiveMutedSurface)
                     .clipShape(Capsule())
             }
         }
         .padding(.horizontal, 18)
         .padding(.vertical, 18)
         .frame(maxWidth: .infinity)
-        .background(.white)
+        .background(Color.adaptiveSurface)
         .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
         .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }

--- a/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Login/Core/LoginReducer.swift
@@ -78,7 +78,7 @@ struct LoginReducer {
                         return (studentInfo, report, chapel)
                     }))
                 }
-            case .loginResponse(.success(let (studentInfo, _, _))):
+            case .loginResponse(.success(let (_, _, _))):
                 state.isLoading = false
                 YDSToast("로그인 성공하였습니다.", haptic: .success)
                 return .none

--- a/Soomsil-USaint/Application/Feature/Login/View/LoginView.swift
+++ b/Soomsil-USaint/Application/Feature/Login/View/LoginView.swift
@@ -6,33 +6,68 @@
 //
 
 import SwiftUI
+import UIKit
 
 import ComposableArchitecture
 import YDS_SwiftUI
 
-private enum Dimension {
-    enum VStack {
-        static let spacing: CGFloat = 8
-    }
-    enum Button {
-        static let minHeight: CGFloat = 48
-    }
-    static let largeSpace: CGFloat = 44
-    static let padding: CGFloat = 16
-}
-
 struct LoginView: View {
     @Bindable var store: StoreOf<LoginReducer>
+    @State private var isPasswordSecured = true
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            LoginLogoView()
+                .padding(.top, 96)
+                .padding(.bottom, 64)
 
-        VStack(spacing: 4) {
-            title
-            LoginForm(id: $store.id, password: $store.password) {
-                store.send(.loginPressed)
+            VStack(alignment: .leading, spacing: 12) {
+                Text("유세인트에\n로그인해주세요")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundStyle(Color.adaptivePrimaryText)
+                    .lineSpacing(4)
+
+                Text("학사 정보를 한눈에 확인할 수 있어요")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(Color.adaptiveSecondaryText)
             }
+            .padding(.bottom, 76)
+
+            VStack(spacing: 12) {
+                LoginInputRow(
+                    placeholder: "학번",
+                    text: $store.id,
+                    isSecure: false,
+                    isPasswordSecured: .constant(false)
+                )
+
+                LoginInputRow(
+                    placeholder: "비밀번호",
+                    text: $store.password,
+                    isSecure: true,
+                    isPasswordSecured: $isPasswordSecured
+                )
+            }
+            .padding(.bottom, 70)
+
+            Button {
+                store.send(.loginPressed)
+            } label: {
+                Text("로그인")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 70)
+                    .background(.blue600)
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            }
+            .buttonStyle(.plain)
+
             Spacer()
         }
+        .padding(.horizontal, 28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(Color.adaptiveBackground)
         .background {
             Color.clear.tapToHideKeyboard()
         }
@@ -45,56 +80,88 @@ struct LoginView: View {
         .onAppear {
             store.send(.onAppear)
         }
-
-    }
-
-    struct LoginForm: View {
-        @Binding var id: String
-        @Binding var password: String
-
-        let onLoginPressed: () -> Void
-
-        var body: some View {
-            VStack(alignment: .leading, spacing: Dimension.VStack.spacing) {
-                Text("학번")
-                    .font(YDSFont.body1)
-                    .foregroundStyle(.titleText)
-                YDSSimpleTextField(text: $id)
-
-                Text("유세인트 비밀번호")
-                    .font(YDSFont.body1)
-                    .foregroundStyle(.titleText)
-                SecureTextField(text: $password)
-                    .padding(.bottom, Dimension.largeSpace)
-
-                Button {
-                    onLoginPressed()
-                } label: {
-                    Text("로그인")
-                        .foregroundStyle(.smallText)
-                        .font(YDSFont.button4)
-                        .frame(maxWidth: .infinity, minHeight: Dimension.Button.minHeight)
-                        .background(.vPrimary, in: RoundedRectangle(cornerRadius: 5))
-                }
-                .buttonStyle(.plain)
-
-                HStack {
-                    YDSIcon.warningcircleLine
-                        .renderingMode(.template)
-                    Text("숨쉴때 유세인트 서비스 이용을 위한 유세인트 학번 및 비밀번호는 사용자 기기에만 저장되며, 유어슈는 유세인트 서비스를 통하여 이용자의 정보를 일체 수집ㆍ저장하지 않습니다.")
-                        .font(.caption2)
-                }
-                .foregroundStyle(.vPrimary)
-            }
-            .padding(Dimension.padding)
-        }
     }
 }
 
-private extension LoginView {
-    var title: some View {
-        Text("로그인")
-            .font(YDSFont.subtitle2)
+private struct LoginLogoView: View {
+    var body: some View {
+        Group {
+            if let icon = AppIconLoader.image {
+                Image(uiImage: icon)
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                RoundedRectangle(cornerRadius: 26, style: .continuous)
+                    .fill(.gray200)
+            }
+        }
+        .frame(width: 96, height: 96)
+        .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+    }
+}
+
+private struct LoginInputRow: View {
+    let placeholder: String
+    @Binding var text: String
+    let isSecure: Bool
+    @Binding var isPasswordSecured: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(placeholder)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundStyle(Color.adaptiveSecondaryText)
+
+            if isSecure && isPasswordSecured {
+                SecureField("", text: $text)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(Color.adaptivePrimaryText)
+            } else {
+                TextField("", text: $text)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(isSecure ? .default : .numberPad)
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(Color.adaptivePrimaryText)
+            }
+
+            if isSecure {
+                Button {
+                    isPasswordSecured.toggle()
+                } label: {
+                    Image(systemName: isPasswordSecured ? "eye" : "eye.slash")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(Color.adaptiveSecondaryText)
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .font(.system(size: 16, weight: .bold))
+        .padding(.horizontal, 24)
+        .frame(height: 68)
+        .background(Color.adaptiveInputSurface)
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
+        )
+    }
+}
+
+private enum AppIconLoader {
+    static var image: UIImage? {
+        guard
+            let icons = Bundle.main.object(forInfoDictionaryKey: "CFBundleIcons") as? [String: Any],
+            let primaryIcon = icons["CFBundlePrimaryIcon"] as? [String: Any],
+            let iconFiles = primaryIcon["CFBundleIconFiles"] as? [String],
+            let iconName = iconFiles.last
+        else {
+            return nil
+        }
+        return UIImage(named: iconName)
     }
 }
 

--- a/Soomsil-USaint/Application/Feature/Login/View/LoginView.swift
+++ b/Soomsil-USaint/Application/Feature/Login/View/LoginView.swift
@@ -18,8 +18,8 @@ struct LoginView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             LoginLogoView()
-                .padding(.top, 96)
-                .padding(.bottom, 64)
+                .padding(.top, 32)
+                .padding(.bottom, 44)
 
             VStack(alignment: .leading, spacing: 12) {
                 Text("유세인트에\n로그인해주세요")
@@ -31,7 +31,7 @@ struct LoginView: View {
                     .font(.system(size: 15, weight: .medium))
                     .foregroundStyle(Color.adaptiveSecondaryText)
             }
-            .padding(.bottom, 76)
+            .padding(.bottom, 78)
 
             VStack(spacing: 12) {
                 LoginInputRow(
@@ -48,7 +48,7 @@ struct LoginView: View {
                     isPasswordSecured: $isPasswordSecured
                 )
             }
-            .padding(.bottom, 70)
+            .padding(.bottom, 68)
 
             Button {
                 store.send(.loginPressed)
@@ -57,7 +57,7 @@ struct LoginView: View {
                     .font(.system(size: 16, weight: .bold))
                     .foregroundStyle(.white)
                     .frame(maxWidth: .infinity)
-                    .frame(height: 70)
+                    .frame(height: 58)
                     .background(.blue600)
                     .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             }
@@ -141,7 +141,7 @@ private struct LoginInputRow: View {
         }
         .font(.system(size: 16, weight: .bold))
         .padding(.horizontal, 24)
-        .frame(height: 68)
+        .frame(height: 58)
         .background(Color.adaptiveInputSurface)
         .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(

--- a/Soomsil-USaint/Application/Feature/Notification/View/NotificationSettingsView.swift
+++ b/Soomsil-USaint/Application/Feature/Notification/View/NotificationSettingsView.swift
@@ -69,7 +69,7 @@ struct NotificationSettingsView: View {
                 .padding(.bottom, 44)
             }
         }
-        .background(.white)
+        .background(Color.adaptiveBackground)
     }
 
     private var header: some View {
@@ -77,14 +77,14 @@ struct NotificationSettingsView: View {
             Button(action: close) {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(.gray950)
+                    .foregroundStyle(Color.adaptivePrimaryText)
                     .frame(width: 28, height: 44)
             }
             .buttonStyle(.plain)
 
             Text(TextLiteral.NotificationSettingsView.title)
                 .font(.system(size: 18, weight: .bold))
-                .foregroundStyle(.gray950)
+                .foregroundStyle(Color.adaptivePrimaryText)
 
             Spacer()
         }
@@ -93,7 +93,7 @@ struct NotificationSettingsView: View {
         .padding(.bottom, 14)
         .overlay(alignment: .bottom) {
             Rectangle()
-                .fill(.slate100)
+                .fill(Color.adaptiveBorder)
                 .frame(height: 1)
         }
     }
@@ -142,14 +142,14 @@ struct NotificationSettingsView: View {
 
     private var divider: some View {
         Rectangle()
-            .fill(.slate100)
+            .fill(Color.adaptiveBorder)
             .frame(height: 1)
     }
 
     private func sectionTitle(_ title: String) -> some View {
         Text(title)
             .font(.system(size: 14, weight: .semibold))
-            .foregroundStyle(.slate400)
+            .foregroundStyle(Color.adaptiveSecondaryText)
             .padding(.bottom, 16)
     }
 
@@ -164,7 +164,7 @@ struct NotificationSettingsView: View {
                     .foregroundStyle(.white)
                     .frame(maxWidth: .infinity)
                     .frame(height: 52)
-                    .background(isNotificationTypeEnabled ? .blue600 : .slate300)
+                    .background(isNotificationTypeEnabled ? .blue600 : Color.adaptiveMutedSurface)
                     .clipShape(RoundedRectangle(cornerRadius: 12))
             }
             .buttonStyle(.plain)
@@ -172,7 +172,7 @@ struct NotificationSettingsView: View {
 
             Text(TextLiteral.NotificationSettingsView.debugSendTestNotificationSubtitle)
                 .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.slate400)
+                .foregroundStyle(Color.adaptiveSecondaryText)
         }
         .padding(.top, 32)
     }
@@ -191,11 +191,11 @@ private struct NotificationSettingRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(.system(size: 17, weight: .bold))
-                    .foregroundStyle(isEnabled ? .gray950 : .slate400)
+                    .foregroundStyle(isEnabled ? Color.adaptivePrimaryText : Color.adaptiveSecondaryText)
 
                 Text(subtitle)
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.slate400)
+                    .foregroundStyle(Color.adaptiveSecondaryText)
             }
 
             Spacer()

--- a/Soomsil-USaint/Application/Feature/Notification/View/NotificationView.swift
+++ b/Soomsil-USaint/Application/Feature/Notification/View/NotificationView.swift
@@ -52,16 +52,22 @@ struct NotificationView: View {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 0) {
                     summary
-                    featuredNotice
+                    if unreadCount > 0 {
+                        featuredNotice
+                    }
                     categoryTabs
                     retentionBanner
-                    notificationList
+                    if unreadCount > 0 {
+                        notificationList
+                    } else {
+                        emptyState
+                    }
                 }
                 .padding(.bottom, 24)
             }
-            .background(.white)
+            .background(Color.adaptiveBackground)
         }
-        .background(.white)
+        .background(Color.adaptiveBackground)
         .fullScreenCover(isPresented: $showsSettings) {
             NotificationSettingsContainerView(
                 close: {
@@ -75,7 +81,7 @@ struct NotificationView: View {
         HStack {
             Text(TextLiteral.NotificationView.title)
                 .font(.system(size: 22, weight: .bold))
-                .foregroundStyle(.gray950)
+                .foregroundStyle(Color.adaptivePrimaryText)
 
             Spacer()
 
@@ -100,16 +106,16 @@ struct NotificationView: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(TextLiteral.NotificationView.unreadTitle)
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(.slate300)
+                        .foregroundStyle(Color.adaptiveSecondaryText)
 
                     HStack(alignment: .lastTextBaseline, spacing: 4) {
                         Text("\(unreadCount)")
                             .font(.system(size: 36, weight: .heavy))
-                            .foregroundStyle(.gray950)
+                            .foregroundStyle(Color.adaptivePrimaryText)
 
                         Text(TextLiteral.NotificationView.countUnit)
                             .font(.system(size: 20, weight: .bold))
-                            .foregroundStyle(.gray950)
+                            .foregroundStyle(Color.adaptivePrimaryText)
                     }
                 }
 
@@ -138,7 +144,7 @@ struct NotificationView: View {
             if unreadCount > 0 {
                 Label(TextLiteral.NotificationView.unreadDescription, systemImage: "info.circle")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.slate300)
+                    .foregroundStyle(Color.adaptiveSecondaryText)
             }
         }
         .padding(.horizontal, 20)
@@ -151,26 +157,26 @@ struct NotificationView: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text(TextLiteral.NotificationView.featuredTitle)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(.gray950)
+                    .foregroundStyle(Color.adaptivePrimaryText)
 
                 Text(TextLiteral.NotificationView.featuredSubtitle)
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.slate300)
+                    .foregroundStyle(Color.adaptiveSecondaryText)
             }
 
             Spacer()
 
             RoundedRectangle(cornerRadius: 4)
-                .fill(.gray150)
+                .fill(Color.adaptiveSecondaryText)
                 .frame(width: 16, height: 16)
                 .accessibilityHidden(true)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
-        .background(.white)
+        .background(Color.adaptiveSurface)
         .overlay(
             RoundedRectangle(cornerRadius: 16)
-                .stroke(.slate100, lineWidth: 1)
+                .stroke(Color.adaptiveBorder, lineWidth: 1)
         )
         .clipShape(RoundedRectangle(cornerRadius: 16))
         .padding(.horizontal, 20)
@@ -186,10 +192,10 @@ struct NotificationView: View {
                     VStack(spacing: 8) {
                         Text(category.title)
                             .font(.system(size: 14, weight: selectedCategory == category ? .semibold : .medium))
-                            .foregroundStyle(selectedCategory == category ? .gray950 : .slate300)
+                            .foregroundStyle(selectedCategory == category ? Color.adaptivePrimaryText : Color.adaptiveSecondaryText)
 
                         Capsule()
-                            .fill(selectedCategory == category ? .gray950 : .white)
+                            .fill(selectedCategory == category ? Color.adaptivePrimaryText : Color.clear)
                             .frame(width: selectedCategory == category ? 32 : 24, height: 2)
                     }
                     .padding(.vertical, 12)
@@ -202,12 +208,12 @@ struct NotificationView: View {
         .padding(.horizontal, 20)
         .overlay(alignment: .top) {
             Rectangle()
-                .fill(.slate100)
+                .fill(Color.adaptiveBorder)
                 .frame(height: 1)
         }
         .overlay(alignment: .bottom) {
             Rectangle()
-                .fill(.slate100)
+                .fill(Color.adaptiveBorder)
                 .frame(height: 1)
         }
     }
@@ -215,11 +221,11 @@ struct NotificationView: View {
     private var retentionBanner: some View {
         Label(TextLiteral.NotificationView.retentionNotice, systemImage: "info.circle")
             .font(.system(size: 12, weight: .medium))
-            .foregroundStyle(.slate500)
+            .foregroundStyle(Color.adaptiveSecondaryText)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 20)
             .padding(.vertical, 12)
-            .background(.gray25)
+            .background(Color.adaptiveSurface)
     }
 
     private var notificationList: some View {
@@ -234,6 +240,49 @@ struct NotificationView: View {
 
 }
 
+private extension NotificationView {
+    var emptyState: some View {
+        VStack(spacing: 18) {
+            ZStack {
+                Circle()
+                    .fill(Color.adaptiveMutedSurface)
+                    .frame(width: 76, height: 76)
+
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.gray200)
+                    .frame(width: 32, height: 32)
+            }
+
+            VStack(spacing: 10) {
+                Text("아직 받은 알림이 없어요")
+                    .font(.system(size: 17, weight: .bold))
+                    .foregroundStyle(Color.adaptivePrimaryText)
+
+                Text("새로운 학사 소식이 도착하면\n여기서 바로 알려드릴게요")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Color.adaptiveSecondaryText)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+            }
+
+            Button {
+                showsSettings = true
+            } label: {
+                Text("알림 받기 설정하기")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(Color.adaptivePrimaryText)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 12)
+                    .background(Color.adaptiveMutedSurface)
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 128)
+    }
+}
+
 private struct NotificationSectionView: View {
     let section: NotificationSection
 
@@ -242,11 +291,11 @@ private struct NotificationSectionView: View {
             HStack(spacing: 0) {
                 Text(section.title)
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.slate300)
+                    .foregroundStyle(Color.adaptiveSecondaryText)
 
                 Text("  ·  \(section.notifications.count)건")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.gray200)
+                    .foregroundStyle(Color.adaptiveTertiaryText)
 
                 Spacer()
             }
@@ -258,7 +307,7 @@ private struct NotificationSectionView: View {
 
                 if index < section.notifications.count - 1 {
                     Divider()
-                        .foregroundStyle(.slate100)
+                        .foregroundStyle(Color.adaptiveBorder)
                 }
             }
         }
@@ -273,7 +322,7 @@ private struct NotificationRowView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(notification.title)
                     .font(.system(size: 14, weight: notification.isRead ? .medium : .semibold))
-                    .foregroundStyle(notification.isRead ? .slate500 : .gray950)
+                    .foregroundStyle(notification.isRead ? Color.adaptiveTertiaryText : Color.adaptivePrimaryText)
                     .lineLimit(1)
 
                 if let subtitle = notification.subtitle {
@@ -282,19 +331,19 @@ private struct NotificationRowView: View {
 
                         if let time = notification.time {
                             Circle()
-                                .fill(.slate300)
+                                .fill(Color.adaptiveSecondaryText)
                                 .frame(width: 3, height: 3)
 
                             Text(time)
                         }
                     }
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(notification.isRead ? .slate300 : .slate500)
+                    .foregroundStyle(notification.isRead ? Color.adaptiveTertiaryText : Color.adaptiveSecondaryText)
                     .lineLimit(1)
                 } else if let time = notification.time {
                     Text(time)
                         .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(.slate300)
+                        .foregroundStyle(Color.adaptiveTertiaryText)
                 }
             }
 

--- a/Soomsil-USaint/Application/Feature/Semester/CurrentSemester/View/CurrentSemesterGradesView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/CurrentSemester/View/CurrentSemesterGradesView.swift
@@ -32,7 +32,7 @@ struct CurrentSemesterGradesView: View {
         .padding(.top, 48)
         .padding(.horizontal, 20)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(.white)
+        .background(Color.adaptiveBackground)
         .onAppear {
             store.send(.onAppear)
         }
@@ -47,28 +47,28 @@ struct CurrentSemesterGradesView: View {
             VStack(alignment: .leading, spacing: 0) {
                 Text(semesterTitle)
                 .font(.system(size: 22, weight: .bold))
-                .foregroundStyle(.gray950)
+                .foregroundStyle(Color.adaptivePrimaryText)
                 .padding(.bottom, 4)
 
                 Text(semesterTitle)
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.gray500)
+                    .foregroundStyle(Color.adaptiveSecondaryText)
                     .padding(.bottom, 20)
 
                 HStack(alignment: .bottom) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(TextLiteral.CurrentSemesterGradesView.totalGPATitle)
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(.gray500)
+                            .foregroundStyle(Color.adaptiveSecondaryText)
 
                         HStack(alignment: .lastTextBaseline, spacing: 4) {
                             Text(TextLiteral.CurrentSemesterGradesView.averageGPA(lectures.averageGPA))
                                 .font(.system(size: 32, weight: .black))
-                                .foregroundStyle(.gray950)
+                                .foregroundStyle(Color.adaptivePrimaryText)
 
                             Text(TextLiteral.CurrentSemesterGradesView.maxGPA)
                                 .font(.system(size: 16, weight: .medium))
-                                .foregroundStyle(.gray500)
+                                .foregroundStyle(Color.adaptiveSecondaryText)
                         }
                     }
 
@@ -133,11 +133,11 @@ struct CurrentSemesterGradesView: View {
             VStack(alignment: .trailing, spacing: 6) {
                 Text(title)
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.gray500)
+                    .foregroundStyle(Color.adaptiveSecondaryText)
 
                 Text(value)
                     .font(.system(size: 16, weight: .bold))
-                    .foregroundStyle(.gray950)
+                    .foregroundStyle(Color.adaptivePrimaryText)
             }
         }
     }
@@ -152,11 +152,11 @@ struct CurrentSemesterGradesView: View {
                 VStack(spacing: 8) {
                     Text(TextLiteral.CurrentSemesterGradesView.emptyTitle)
                         .font(.system(size: 16, weight: .bold))
-                        .foregroundColor(.gray950)
+                        .foregroundColor(Color.adaptivePrimaryText)
                     
                     Text(TextLiteral.CurrentSemesterGradesView.emptyDescription)
                         .font(.system(size: 13, weight: .regular))
-                        .foregroundColor(.gray500)
+                        .foregroundColor(Color.adaptiveSecondaryText)
                         .multilineTextAlignment(.center)
                 }
             }

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterDetailView.swift
@@ -51,7 +51,7 @@ struct SemesterDetailView: View {
                 }
             }
         }
-        .background(.white)
+        .background(Color.adaptiveBackground)
         .overlay(
             store.isLoading ? CircleLoadingView() : nil
         )
@@ -68,7 +68,7 @@ struct SemesterDetailView: View {
                         Text(TextLiteral.SemesterDetailView.title)
                             .font(.custom("AppleSDGothicNeo-Bold", size: 20))
                     }
-                    .foregroundStyle(.titleText)
+                    .foregroundStyle(Color.adaptivePrimaryText)
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
@@ -79,7 +79,7 @@ struct SemesterDetailView: View {
                 } label: {
                     YDSIcon.refreshLine
                         .renderingMode(.template)
-                        .foregroundStyle(.grayText)
+                        .foregroundStyle(Color.adaptiveSecondaryText)
                 }
             }
         }

--- a/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterTabView.swift
+++ b/Soomsil-USaint/Application/Feature/Semester/SemesterDetail/View/SemesterTabView.swift
@@ -54,10 +54,10 @@ private extension SemesterTabView {
         } label: {
             Text(tab.id)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(isSelected ? .white : .slate400)
+                .foregroundStyle(isSelected ? .white : Color.adaptiveSecondaryText)
                 .padding(.horizontal, 17)
                 .padding(.vertical, 8)
-                .background(isSelected ? .gray950 : .gray100)
+                .background(isSelected ? Color.adaptiveSelectedPill : Color.adaptiveMutedSurface)
                 .clipShape(Capsule())
         }
         .buttonStyle(.plain)

--- a/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
@@ -81,26 +81,7 @@ struct RowView: View {
                 .font(.system(size: 15, weight: .semibold))
                 .foregroundStyle(Color.adaptivePrimaryText)
                 .padding(.leading, 16)
-                .frame(height: 58)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(isPressed ? Color.adaptiveMutedSurface : .clear)
-                .gesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { _ in
-                            guard isEnabled else { return }
-                            isPressed = true
-                        }
-                        .onEnded { _ in
-                            guard isEnabled else { return }
-                            isPressed = false
-                            switch rightItem {
-                            case .chevron:
-                                action()
-                            case .none, .text, .toggle:
-                                break
-                            }
-                        }
-                )
             
             switch rightItem {
             case .none:
@@ -126,5 +107,61 @@ struct RowView: View {
                     }
             }
         }
+        .frame(height: 58)
+        .background(isPressed ? Color.adaptiveMutedSurface : .clear)
+        .contentShape(Rectangle())
+        .rowTapGesture(
+            isEnabled: isEnabled && rightItem.isRowTapEnabled,
+            isPressed: $isPressed,
+            action: action
+        )
+    }
+}
+
+private extension RightItem {
+    var isRowTapEnabled: Bool {
+        if case .chevron = self {
+            return true
+        }
+        return false
+    }
+}
+
+private struct RowTapGestureModifier: ViewModifier {
+    let isEnabled: Bool
+    @Binding var isPressed: Bool
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        if isEnabled {
+            content.gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        isPressed = true
+                    }
+                    .onEnded { _ in
+                        isPressed = false
+                        action()
+                    }
+            )
+        } else {
+            content
+        }
+    }
+}
+
+private extension View {
+    func rowTapGesture(
+        isEnabled: Bool,
+        isPressed: Binding<Bool>,
+        action: @escaping () -> Void
+    ) -> some View {
+        modifier(
+            RowTapGestureModifier(
+                isEnabled: isEnabled,
+                isPressed: isPressed,
+                action: action
+            )
+        )
     }
 }

--- a/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/ListRowView.swift
@@ -11,6 +11,8 @@ import YDS_SwiftUI
 
 enum RightItem {
     case none
+    case chevron
+    case text(String)
     case toggle(isPushAuthorizationEnabled: Binding<Bool>)
 }
 
@@ -24,19 +26,33 @@ struct ListRowView: View {
     }
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: 8) {
             Text(title)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(.gray850)
-                .padding(20)
-                .frame(height: 56)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Color.adaptiveSecondaryText)
+                .padding(.horizontal, 2)
             
-            ForEach(items.indices, id: \.self) { index in
-                HStack {
+            VStack(spacing: 0) {
+                ForEach(items.indices, id: \.self) { index in
                     items[index]
+
+                    if index < items.count - 1 {
+                        Rectangle()
+                            .fill(Color.adaptiveBorder)
+                            .frame(height: 1)
+                            .padding(.horizontal, 16)
+                    }
                 }
             }
+            .background(Color.adaptiveSurface)
+            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color.adaptiveBorder, lineWidth: 1)
+            )
         }
+        .padding(.horizontal, 20)
+        .padding(.top, 18)
     }
 }
 
@@ -62,12 +78,12 @@ struct RowView: View {
     var body: some View {
         HStack {
             Text(text)
-                .font(.system(size: 15, weight: .regular))
-                .foregroundStyle(.gray850)
-                .padding(20)
-                .frame(height: 56)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Color.adaptivePrimaryText)
+                .padding(.leading, 16)
+                .frame(height: 58)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(isPressed ? .lightGray : .clear)
+                .background(isPressed ? Color.adaptiveMutedSurface : .clear)
                 .gesture(
                     DragGesture(minimumDistance: 0)
                         .onChanged { _ in
@@ -78,9 +94,9 @@ struct RowView: View {
                             guard isEnabled else { return }
                             isPressed = false
                             switch rightItem {
-                            case .none:
+                            case .chevron:
                                 action()
-                            case .toggle(_):
+                            case .none, .text, .toggle:
                                 break
                             }
                         }
@@ -89,13 +105,22 @@ struct RowView: View {
             switch rightItem {
             case .none:
                 EmptyView()
+            case .chevron:
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Color.adaptiveSecondaryText)
+                    .padding(.trailing, 16)
+            case .text(let text):
+                Text(text)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Color.adaptiveSecondaryText)
+                    .padding(.trailing, 16)
             case .toggle(let isPushAuthorizationEnabled):
                 Toggle("", isOn: isPushAuthorizationEnabled)
                     .labelsHidden()
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 20)
-                    .tint(.blue)
-                    .frame(height: 56)
+                    .padding(.trailing, 16)
+                    .tint(.blue600)
+                    .frame(height: 58)
                     .onChange(of: isPushAuthorizationEnabled.wrappedValue) {
                         action()
                     }

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -12,15 +12,15 @@ import YDS_SwiftUI
 
 struct SettingView: View {
     @Bindable var store: StoreOf<SettingReducer>
-    @State private var showsNotificationSettings = false
     
     var body: some View {
         VStack(spacing: 0) {
             Text(TextLiteral.SettingView.title)
                 .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(.gray950)
+                .foregroundStyle(Color.adaptivePrimaryText)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 6.5)
+                .padding(.top, 52)
+                .padding(.bottom, 8)
 
             SettingList(
                 appVersion: store.appVersion
@@ -28,8 +28,6 @@ struct SettingView: View {
                 switch tappedItem {
                 case .logout:
                     store.send(.logoutButtonTapped)
-                case .notificationSettings:
-                    showsNotificationSettings = true
                 case .termsOfService:
                     store.send(.termsOfServiceButtonTapped)
                 case .privacyPolicy:
@@ -41,45 +39,46 @@ struct SettingView: View {
         .alert(
             $store.scope(state: \.alert, action: \.alert)
         )
-        .fullScreenCover(isPresented: $showsNotificationSettings) {
-            NotificationSettingsContainerView {
-                showsNotificationSettings = false
-            }
-        }
         .onAppear {
             store.send(.onAppear)
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(Color.adaptiveBackground)
     }
     
     struct SettingList: View {
         let appVersion: String
         let listItemTapped: (listItem) -> Void
+        @AppStorage("gradeAnnouncementNotificationEnabled") private var isGradeNotificationEnabled = true
+        @AppStorage("chapelNotificationEnabled") private var isCampusNotificationEnabled = true
         
         var body: some View {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 0) {
                 ListRowView(
                     title: TextLiteral.SettingView.accountSectionTitle,
                     items: [
                         RowView(text: TextLiteral.SettingView.logoutButtonTitle,
-                                rightItem: .none,
+                                rightItem: .chevron,
                                 action: {
                                     listItemTapped(.logout)
                                 }
                                )
                     ]
                 )
-                
-                Divider()
-                
+
                 ListRowView(
                     title: TextLiteral.SettingView.notificationSectionTitle,
                     items: [
-                        RowView(text: TextLiteral.SettingView.notificationSettingsTitle,
-                                rightItem: .none,
-                                action: {
-                                    listItemTapped(.notificationSettings)
-                                }
-                               )
+                        RowView(
+                            text: TextLiteral.SettingView.gradeNotificationTitle,
+                            rightItem: .toggle(isPushAuthorizationEnabled: $isGradeNotificationEnabled),
+                            action: {}
+                        ),
+                        RowView(
+                            text: TextLiteral.SettingView.campusNotificationTitle,
+                            rightItem: .toggle(isPushAuthorizationEnabled: $isCampusNotificationEnabled),
+                            action: {}
+                        )
                     ])
                 
                 ListRowView(
@@ -87,29 +86,27 @@ struct SettingView: View {
                     items: [
                         RowView(
                             text: TextLiteral.SettingView.termsOfServiceTitle,
-                            rightItem: .none,
+                            rightItem: .chevron,
                             action: {
                                 listItemTapped(.termsOfService)
                             }
                         ),
                         RowView(
                             text: TextLiteral.SettingView.privacyPolicyTitle,
-                            rightItem: .none,
+                            rightItem: .chevron,
                             action: {
                                 listItemTapped(.privacyPolicy)
                             }
                         )
                     ]
                 )
-                
-                Divider()
-                
+
                 ListRowView(
                     title: TextLiteral.SettingView.versionSectionTitle,
                     items: [
                         RowView(
-                            text: TextLiteral.SettingView.appVersion(appVersion),
-                            rightItem: .none,
+                            text: "버전정보",
+                            rightItem: .text(TextLiteral.SettingView.appVersion(appVersion)),
                             isEnabled: false,
                             action: {}
                         )
@@ -134,11 +131,11 @@ struct LogoutDialogView: View {
                 VStack(spacing: 9) {
                     Text(TextLiteral.SettingReducer.logoutAlertTitle)
                         .font(.system(size: 18, weight: .bold))
-                        .foregroundStyle(.gray950)
+                        .foregroundStyle(Color.adaptivePrimaryText)
 
                     Text(TextLiteral.SettingReducer.logoutAlertMessage)
                         .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(.slate500)
+                        .foregroundStyle(Color.adaptiveSecondaryText)
                         .multilineTextAlignment(.center)
                         .lineSpacing(3)
                 }
@@ -147,10 +144,10 @@ struct LogoutDialogView: View {
                     Button(action: cancel) {
                         Text(TextLiteral.SettingReducer.alertCancelTitle)
                             .font(.system(size: 15, weight: .bold))
-                            .foregroundStyle(.gray950)
+                            .foregroundStyle(Color.adaptivePrimaryText)
                             .frame(maxWidth: .infinity)
                             .frame(height: 48)
-                            .background(.gray25)
+                            .background(Color.adaptiveMutedSurface)
                             .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
                     .buttonStyle(.plain)
@@ -170,7 +167,7 @@ struct LogoutDialogView: View {
             .padding(.top, 40)
             .padding(.horizontal, 34)
             .padding(.bottom, 28)
-            .background(.white)
+            .background(Color.adaptiveSurface)
             .clipShape(RoundedRectangle(cornerRadius: 18))
             .padding(.horizontal, 34)
         }
@@ -179,7 +176,6 @@ struct LogoutDialogView: View {
 
 enum listItem {
     case logout
-    case notificationSettings
     case termsOfService
     case privacyPolicy
 }

--- a/Soomsil-USaint/Global/Utils/TextLiteral.swift
+++ b/Soomsil-USaint/Global/Utils/TextLiteral.swift
@@ -28,18 +28,19 @@ enum TextLiteral {
 
     enum SettingView {
         static let title = "설정"
-        static let accountSectionTitle = "계정관리"
+        static let accountSectionTitle = "계정"
         static let logoutButtonTitle = "로그아웃"
         static let notificationSectionTitle = "알림"
         static let gradeNotificationTitle = "성적 알림 받기"
+        static let campusNotificationTitle = "캠퍼스 알림 받기"
         static let notificationSettingsTitle = "알림 설정"
         static let termsSectionTitle = "약관"
         static let termsOfServiceTitle = "이용약관"
-        static let privacyPolicyTitle = "개인정보수집 및 허용"
-        static let versionSectionTitle = "버전 정보"
+        static let privacyPolicyTitle = "개인정보 처리 방침"
+        static let versionSectionTitle = "버전"
 
         static func appVersion(_ version: String) -> String {
-            "v.\(version)"
+            "v\(version)"
         }
     }
 


### PR DESCRIPTION
## 📌 Summary
유세인트 v2 리디자인 흐름에 맞춰 주요 화면의 iOS 다크모드 대응을 보강하고, 알림/마이페이지 설정/로그인 화면의 UI와 상호작용을 정리했습니다.


## ✍️ Description
- 이슈 티켓 : #171
- 피그마 : https://www.figma.com/design/Uxh9MW8UjFYtS8Nt4VHnTh/soomsil_usaint?node-id=30-367&t=fGDBGavQ3HeFfsHT-1
- 관련 문서 : 없음
- close: #171

### 주요 변경 사항
- iOS 시스템 다크모드에서만 적용되는 adaptive 색상 토큰을 추가했습니다.
- 홈, 성적, 채플, 알림, 탭바 등 주요 화면 배경/텍스트/카드/보더 색상을 다크모드에 맞게 연결했습니다.
- 알림 화면에 빈 상태 UI를 추가하고, 알림 설정 이동 CTA를 연결했습니다.
- 알림 설정 화면의 배경, 구분선, 텍스트, 비활성 버튼 색상을 다크모드에 맞게 조정했습니다.
- 마이페이지 설정 화면을 카드형 섹션 구조로 정리하고, 성적/캠퍼스 알림 토글을 설정 화면에 직접 배치했습니다.
- 설정 셀 터치 정책을 정리했습니다.
  - 로그아웃/약관처럼 이동 가능한 셀은 셀 전체 터치 가능
  - 알림 토글 셀은 토글 버튼만 터치 가능
  - 버전 정보 셀은 터치 불가
- 로그인 화면을 리디자인 시안에 맞춰 로고, 타이틀, 입력 필드, 버튼 중심의 레이아웃으로 개편했습니다.
- 로그인 성공 처리에서 사용하지 않는 바인딩 값을 정리했습니다.


## 💡 PR Point
- `.background(Color.darkBackground)`처럼 화면을 강제로 다크 컬러로 바꾸지 않고, `UIColor` dynamic provider 기반의 adaptive `Color`를 추가해 iOS 시스템 다크모드 설정에 따라 자동으로 색상이 바뀌도록 처리했습니다.
- 마이페이지 설정 행은 같은 `RowView`를 쓰되 `RightItem` 타입에 따라 터치 가능 여부를 분리했습니다. 이 방식으로 토글 행이 셀 전체 탭으로 오작동하지 않게 했습니다.
- 로그인 화면은 기존 기능 흐름은 유지하면서 디자인만 변경했습니다. 저장된 학번/비밀번호 로딩, 로그인 액션, 로딩 오버레이, 비밀번호 보기 토글은 그대로 동작합니다.

## 📚 Reference 
- Figma Group D - 푸시 알림/설정/로그인 관련 시안


## 🔥 Test

<img width="414" height="855" alt="스크린샷 2026-06-01 오전 2 31 44" src="https://github.com/user-attachments/assets/12f1c1bb-32c2-4932-8d90-b6386e25d209" />

https://github.com/user-attachments/assets/a45a2a96-2788-496d-8f88-e310ad9fe550

