### PR TITLE
[#173] 푸시 알림 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,4 +153,7 @@ xcuserdata
 
 secretConfig.xcconfig
 
+# Firebase configuration
+**/GoogleService-Info.plist
+
 # End of https://www.toptal.com/developers/gitignore/api/xcode,git,macos,swift,swiftpackagemanager

--- a/.gitignore
+++ b/.gitignore
@@ -156,4 +156,7 @@ secretConfig.xcconfig
 # Firebase configuration
 **/GoogleService-Info.plist
 
+# Local agent instructions
+AGENTS.md
+
 # End of https://www.toptal.com/developers/gitignore/api/xcode,git,macos,swift,swiftpackagemanager

--- a/Soomsil-USaint.xcodeproj/project.pbxproj
+++ b/Soomsil-USaint.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A5B8C6152E894D2E00727818 /* Rusaint in Frameworks */ = {isa = PBXBuildFile; productRef = A5B8C6142E894D2E00727818 /* Rusaint */; };
 		B96F06662D63882B0047D33D /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = B96F06652D63882B0047D33D /* FirebaseCore */; };
 		B96F06682D63882B0047D33D /* FirebaseRemoteConfig in Frameworks */ = {isa = PBXBuildFile; productRef = B96F06672D63882B0047D33D /* FirebaseRemoteConfig */; };
+		B96F066A2D63882B0047D33D /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = B96F06692D63882B0047D33D /* FirebaseMessaging */; };
 		E50A23E12E68994B00EB7129 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = E50A23E02E68994B00EB7129 /* Mixpanel */; };
 /* End PBXBuildFile section */
 
@@ -57,6 +58,7 @@
 				02C46CF52D0F2E9300A3E717 /* YDS-SwiftUI in Frameworks */,
 				02C46D8F2D0F45B200A3E717 /* RxCocoa in Frameworks */,
 				B96F06662D63882B0047D33D /* FirebaseCore in Frameworks */,
+				B96F066A2D63882B0047D33D /* FirebaseMessaging in Frameworks */,
 				02C46D8D2D0F45B200A3E717 /* RxBlocking in Frameworks */,
 				B96F06682D63882B0047D33D /* FirebaseRemoteConfig in Frameworks */,
 				A5B8C6152E894D2E00727818 /* Rusaint in Frameworks */,
@@ -111,6 +113,7 @@
 				02C46D902D0F45B200A3E717 /* RxRelay */,
 				B96F06652D63882B0047D33D /* FirebaseCore */,
 				B96F06672D63882B0047D33D /* FirebaseRemoteConfig */,
+				B96F06692D63882B0047D33D /* FirebaseMessaging */,
 				7B07475D2E095DDF00A055C7 /* ComposableArchitecture */,
 				E50A23E02E68994B00EB7129 /* Mixpanel */,
 				A5B8C6142E894D2E00727818 /* Rusaint */,
@@ -309,6 +312,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Soomsil-USaint/Soomsil-USaint.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2025090803;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -348,6 +352,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = "Soomsil-USaint/Soomsil-USaint.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 2025090803;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -512,6 +517,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = B96F06642D63882B0047D33D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseRemoteConfig;
+		};
+		B96F06692D63882B0047D33D /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B96F06642D63882B0047D33D /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 		E50A23E02E68994B00EB7129 /* Mixpanel */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -52,6 +52,7 @@ struct HomeReducer {
     }
     
     @Dependency(\.localNotificationClient) var localNotificationClient
+    @Dependency(\.remoteNotificationClient) var remoteNotificationClient
     @Dependency(\.studentClient) var studentClient
     @Dependency(\.gradeClient) var gradeClient
     @Dependency(\.chapelClient) var chapelClient
@@ -120,17 +121,29 @@ struct HomeReducer {
 
             case .checkPushAuthorizationResponse(.success(let granted)):
                 state.$permission.withLock { $0 = granted }
-                return .none
+                return .run { _ in
+                    if granted {
+                        await remoteNotificationClient.registerDeviceIfAuthorized()
+                    }
+                    await remoteNotificationClient.syncTopicSubscriptions()
+                }
             case .checkPushAuthorizationResponse(.failure(let error)):
                 debugPrint("Home Reducer: CheckPushAuthorization Error - \(error)")
                 return .none
             case .notificationPermissionResponse(.success(let granted)):
                 state.$permission.withLock { $0 = granted }
-                return .none
+                return .run { _ in
+                    if granted {
+                        await remoteNotificationClient.registerDeviceIfAuthorized()
+                    }
+                    await remoteNotificationClient.syncTopicSubscriptions()
+                }
             case .notificationPermissionResponse(.failure(let error)):
                 debugPrint("Home Reducer: RequestPushAuthorization Error - \(error)")
                 state.$permission.withLock { $0 = false }
-                return .none
+                return .run { _ in
+                    await remoteNotificationClient.syncTopicSubscriptions()
+                }
             case .semesterDetailPressed:
                 state.path.append(.semesterDetail(SemesterDetailReducer.State()))
                 return .none

--- a/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Home/Core/HomeReducer.swift
@@ -53,6 +53,7 @@ struct HomeReducer {
     
     @Dependency(\.localNotificationClient) var localNotificationClient
     @Dependency(\.remoteNotificationClient) var remoteNotificationClient
+    @Dependency(\.alarmBackendClient) var alarmBackendClient
     @Dependency(\.studentClient) var studentClient
     @Dependency(\.gradeClient) var gradeClient
     @Dependency(\.chapelClient) var chapelClient
@@ -124,6 +125,7 @@ struct HomeReducer {
                 return .run { _ in
                     if granted {
                         await remoteNotificationClient.registerDeviceIfAuthorized()
+                        try? await alarmBackendClient.registerStoredDevice()
                     }
                     await remoteNotificationClient.syncTopicSubscriptions()
                 }
@@ -135,6 +137,7 @@ struct HomeReducer {
                 return .run { _ in
                     if granted {
                         await remoteNotificationClient.registerDeviceIfAuthorized()
+                        try? await alarmBackendClient.registerStoredDevice()
                     }
                     await remoteNotificationClient.syncTopicSubscriptions()
                 }

--- a/Soomsil-USaint/Application/Feature/MainTab/Core/MainTabReducer.swift
+++ b/Soomsil-USaint/Application/Feature/MainTab/Core/MainTabReducer.swift
@@ -49,6 +49,10 @@ struct MainTabReducer {
             case .notificationOpened(.chapel):
                 state.selectedTab = .chapel
                 return .none
+            case .notificationOpened(.currentSemesterGrades):
+                state.selectedTab = .home
+                state.homeState.path.removeAll()
+                return .send(.home(.currentSemesterGradesPressed))
             case .notificationOpened(.notification):
                 state.selectedTab = .notification
                 return .none

--- a/Soomsil-USaint/Application/Feature/Notification/View/NotificationSettingsContainerView.swift
+++ b/Soomsil-USaint/Application/Feature/Notification/View/NotificationSettingsContainerView.swift
@@ -13,6 +13,7 @@ struct NotificationSettingsContainerView: View {
     let close: () -> Void
 
     @Dependency(\.localNotificationClient) private var localNotificationClient
+    @Dependency(\.remoteNotificationClient) private var remoteNotificationClient
 
     @AppStorage("permission") private var isPushNotificationEnabled = false
     @AppStorage("courseRegistrationNotificationEnabled") private var isCourseRegistrationEnabled = true
@@ -38,27 +39,27 @@ struct NotificationSettingsContainerView: View {
             isMarketingEnabled: isMarketingEnabled,
             pushToggleChanged: updatePushNotification,
             courseRegistrationToggleChanged: {
-                updateNotificationType(isOn: $0) {
+                updateNotificationType(.courseRegistration, isOn: $0) {
                     isCourseRegistrationEnabled = $0
                 }
             },
             assignmentDeadlineToggleChanged: {
-                updateNotificationType(isOn: $0) {
+                updateNotificationType(.assignmentDeadline, isOn: $0) {
                     isAssignmentDeadlineEnabled = $0
                 }
             },
             gradeAnnouncementToggleChanged: {
-                updateNotificationType(isOn: $0) {
+                updateNotificationType(.gradeAnnouncement, isOn: $0) {
                     isGradeAnnouncementEnabled = $0
                 }
             },
             chapelToggleChanged: {
-                updateNotificationType(isOn: $0) {
+                updateNotificationType(.chapel, isOn: $0) {
                     isChapelEnabled = $0
                 }
             },
             marketingToggleChanged: {
-                updateNotificationType(isOn: $0) {
+                updateNotificationType(.marketing, isOn: $0) {
                     isMarketingEnabled = $0
                 }
             },
@@ -67,6 +68,7 @@ struct NotificationSettingsContainerView: View {
         )
         .task {
             await refreshAuthorizationStatus()
+            await remoteNotificationClient.syncTopicSubscriptions()
         }
     }
 
@@ -83,12 +85,19 @@ struct NotificationSettingsContainerView: View {
     private func updatePushNotification(_ isOn: Bool) {
         guard isOn else {
             isPushNotificationEnabled = false
+            Task {
+                await remoteNotificationClient.syncTopicSubscriptions()
+            }
             return
         }
 
         switch authorizationStatus {
         case .authorized, .provisional:
             isPushNotificationEnabled = true
+            Task {
+                await remoteNotificationClient.registerDeviceIfAuthorized()
+                await remoteNotificationClient.syncTopicSubscriptions()
+            }
         case .notDetermined:
             requestAuthorization()
         case .denied, .ephemeral:
@@ -98,13 +107,20 @@ struct NotificationSettingsContainerView: View {
         }
     }
 
-    private func updateNotificationType(isOn: Bool, assign: (Bool) -> Void) {
+    private func updateNotificationType(
+        _ category: USaintNotificationCategory,
+        isOn: Bool,
+        assign: (Bool) -> Void
+    ) {
         guard isSystemAuthorized, isPushNotificationEnabled else {
             updatePushNotification(true)
             return
         }
 
         assign(isOn)
+        Task {
+            await remoteNotificationClient.updateTopicSubscription(category, isOn)
+        }
     }
 
     private func requestAuthorization() {
@@ -116,6 +132,11 @@ struct NotificationSettingsContainerView: View {
             }
 
             await refreshAuthorizationStatus()
+
+            if granted {
+                await remoteNotificationClient.registerDeviceIfAuthorized()
+            }
+            await remoteNotificationClient.syncTopicSubscriptions()
         }
     }
 
@@ -148,6 +169,9 @@ struct NotificationSettingsContainerView: View {
                     isPushNotificationEnabled = true
                 }
             }
+
+            await remoteNotificationClient.registerDeviceIfAuthorized()
+            await remoteNotificationClient.syncTopicSubscriptions()
 
             try? await localNotificationClient.setChapelPushNotification(
                 ChapelCard(attendance: 4, seatPosition: "B-12", floorLevel: 1)

--- a/Soomsil-USaint/Application/Feature/Notification/View/NotificationView.swift
+++ b/Soomsil-USaint/Application/Feature/Notification/View/NotificationView.swift
@@ -7,42 +7,39 @@ import SwiftUI
 
 struct NotificationView: View {
     @State private var selectedCategory: NotificationCategory = .all
-    @State private var hasUnreadNotifications = true
+    @State private var notifications: [USaintReceivedNotification] = []
     @State private var showsSettings = false
 
-    private var visibleSections: [NotificationSection] {
-        let unreadSections = NotificationSampleData.sections.map { section in
-            NotificationSection(
-                title: section.title,
-                notifications: section.notifications.map { notification in
-                    NotificationItem(
-                        title: notification.title,
-                        subtitle: notification.subtitle,
-                        time: notification.time,
-                        badge: notification.badge,
-                        category: notification.category,
-                        isRead: hasUnreadNotifications ? notification.isRead : true
-                    )
-                }
-            )
-        }
-
-        guard selectedCategory != .all else {
-            return unreadSections
-        }
-
-        return unreadSections.compactMap { section in
-            let notifications = section.notifications.filter { $0.category == selectedCategory }
-            return notifications.isEmpty ? nil : NotificationSection(title: section.title, notifications: notifications)
+    private var visibleNotifications: [USaintReceivedNotification] {
+        switch selectedCategory {
+        case .all:
+            notifications
+        case .academic:
+            notifications.filter { $0.notificationCategory == .academic }
+        case .classNotice:
+            notifications.filter { $0.notificationCategory == .classNotice }
         }
     }
 
+    private var visibleSections: [NotificationSection] {
+        Dictionary(grouping: visibleNotifications, by: \.sectionTitle)
+            .map { title, notifications in
+                NotificationSection(
+                    title: title,
+                    notifications: notifications
+                        .sorted { $0.sentAt > $1.sentAt }
+                        .map(NotificationItem.init)
+                )
+            }
+            .sorted { $0.sortOrder < $1.sortOrder }
+    }
+
     private var unreadCount: Int {
-        guard hasUnreadNotifications else { return 0 }
-        return NotificationSampleData.sections
-            .flatMap(\.notifications)
-            .filter { !$0.isRead }
-            .count
+        notifications.filter { !$0.isRead }.count
+    }
+
+    private var featuredNotification: USaintReceivedNotification? {
+        notifications.first { !$0.isRead }
     }
 
     var body: some View {
@@ -52,15 +49,15 @@ struct NotificationView: View {
             ScrollView(showsIndicators: false) {
                 VStack(spacing: 0) {
                     summary
-                    if unreadCount > 0 {
-                        featuredNotice
+                    if let featuredNotification {
+                        featuredNotice(featuredNotification)
                     }
                     categoryTabs
                     retentionBanner
-                    if unreadCount > 0 {
-                        notificationList
-                    } else {
+                    if visibleNotifications.isEmpty {
                         emptyState
+                    } else {
+                        notificationList
                     }
                 }
                 .padding(.bottom, 24)
@@ -68,6 +65,12 @@ struct NotificationView: View {
             .background(Color.adaptiveBackground)
         }
         .background(Color.adaptiveBackground)
+        .task {
+            await reloadNotifications()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .usaintReceivedNotificationsDidChange)) { _ in
+            notifications = USaintReceivedNotificationStore.load()
+        }
         .fullScreenCover(isPresented: $showsSettings) {
             NotificationSettingsContainerView(
                 close: {
@@ -122,7 +125,7 @@ struct NotificationView: View {
                 Spacer()
 
                 Button {
-                    hasUnreadNotifications = false
+                    notifications = USaintReceivedNotificationStore.markAllRead()
                 } label: {
                     HStack(spacing: 5) {
                         Image(systemName: "checkmark")
@@ -152,35 +155,42 @@ struct NotificationView: View {
         .padding(.bottom, unreadCount > 0 ? 20 : 8)
     }
 
-    private var featuredNotice: some View {
-        HStack(spacing: 14) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text(TextLiteral.NotificationView.featuredTitle)
+    private func featuredNotice(_ notification: USaintReceivedNotification) -> some View {
+        Button {
+            open(notification)
+        } label: {
+            HStack(spacing: 14) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(notification.title)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Color.adaptivePrimaryText)
+                        .lineLimit(1)
+
+                    Text(notification.body ?? notification.category ?? notification.domain ?? "")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(Color.adaptiveSecondaryText)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(Color.adaptivePrimaryText)
-
-                Text(TextLiteral.NotificationView.featuredSubtitle)
-                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(Color.adaptiveSecondaryText)
+                    .accessibilityHidden(true)
             }
-
-            Spacer()
-
-            RoundedRectangle(cornerRadius: 4)
-                .fill(Color.adaptiveSecondaryText)
-                .frame(width: 16, height: 16)
-                .accessibilityHidden(true)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background(Color.adaptiveSurface)
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(Color.adaptiveBorder, lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .padding(.horizontal, 20)
+            .padding(.bottom, 16)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .background(Color.adaptiveSurface)
-        .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.adaptiveBorder, lineWidth: 1)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 16))
-        .padding(.horizontal, 20)
-        .padding(.bottom, 16)
+        .buttonStyle(.plain)
     }
 
     private var categoryTabs: some View {
@@ -231,13 +241,30 @@ struct NotificationView: View {
     private var notificationList: some View {
         VStack(spacing: 0) {
             ForEach(visibleSections) { section in
-                NotificationSectionView(section: section)
+                NotificationSectionView(section: section, open: open)
             }
         }
         .padding(.horizontal, 20)
         .padding(.top, 8)
     }
 
+    private func reloadNotifications() async {
+        notifications = await USaintReceivedNotificationStore.mergeDeliveredNotifications()
+    }
+
+    private func open(_ notification: USaintReceivedNotification) {
+        notifications = USaintReceivedNotificationStore.markRead(notification.id)
+
+        guard let route = notification.notificationRoute else {
+            return
+        }
+
+        NotificationCenter.default.post(
+            name: .usaintNotificationOpened,
+            object: nil,
+            userInfo: [NotificationUserInfoKey.route: route.rawValue]
+        )
+    }
 }
 
 private extension NotificationView {
@@ -285,6 +312,7 @@ private extension NotificationView {
 
 private struct NotificationSectionView: View {
     let section: NotificationSection
+    let open: (USaintReceivedNotification) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -303,7 +331,9 @@ private struct NotificationSectionView: View {
             .padding(.bottom, 8)
 
             ForEach(Array(section.notifications.enumerated()), id: \.element.id) { index, notification in
-                NotificationRowView(notification: notification)
+                NotificationRowView(notification: notification) {
+                    open(notification.rawNotification)
+                }
 
                 if index < section.notifications.count - 1 {
                     Divider()
@@ -316,45 +346,45 @@ private struct NotificationSectionView: View {
 
 private struct NotificationRowView: View {
     let notification: NotificationItem
+    let open: () -> Void
 
     var body: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(notification.title)
-                    .font(.system(size: 14, weight: notification.isRead ? .medium : .semibold))
-                    .foregroundStyle(notification.isRead ? Color.adaptiveTertiaryText : Color.adaptivePrimaryText)
-                    .lineLimit(1)
+        Button(action: open) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(notification.title)
+                        .font(.system(size: 14, weight: notification.isRead ? .medium : .semibold))
+                        .foregroundStyle(notification.isRead ? Color.adaptiveTertiaryText : Color.adaptivePrimaryText)
+                        .lineLimit(1)
 
-                if let subtitle = notification.subtitle {
                     HStack(spacing: 6) {
-                        Text(subtitle)
+                        if let subtitle = notification.subtitle {
+                            Text(subtitle)
+                        }
 
-                        if let time = notification.time {
+                        if notification.subtitle != nil {
                             Circle()
                                 .fill(Color.adaptiveSecondaryText)
                                 .frame(width: 3, height: 3)
-
-                            Text(time)
                         }
+
+                        Text(notification.time)
                     }
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(notification.isRead ? Color.adaptiveTertiaryText : Color.adaptiveSecondaryText)
                     .lineLimit(1)
-                } else if let time = notification.time {
-                    Text(time)
-                        .font(.system(size: 11, weight: .medium))
-                        .foregroundStyle(Color.adaptiveTertiaryText)
+                }
+
+                Spacer(minLength: 12)
+
+                if let badge = notification.badge {
+                    NotificationBadgeView(badge: badge)
                 }
             }
-
-            Spacer(minLength: 12)
-
-            if let badge = notification.badge {
-                NotificationBadgeView(badge: badge)
-            }
+            .padding(.vertical, 12)
+            .opacity(notification.isRead ? 0.55 : 1)
         }
-        .padding(.vertical, 12)
-        .opacity(notification.isRead ? 0.55 : 1)
+        .buttonStyle(.plain)
     }
 }
 
@@ -394,19 +424,41 @@ private enum NotificationCategory: CaseIterable {
 }
 
 private struct NotificationSection: Identifiable {
-    let id = UUID()
     let title: String
     let notifications: [NotificationItem]
+
+    var id: String { title }
+
+    var sortOrder: Int {
+        switch title {
+        case "오늘":
+            0
+        case "이번 주":
+            1
+        default:
+            2
+        }
+    }
 }
 
 private struct NotificationItem: Identifiable {
-    let id = UUID()
+    let rawNotification: USaintReceivedNotification
     let title: String
     let subtitle: String?
-    let time: String?
+    let time: String
     let badge: NotificationBadge?
-    let category: NotificationCategory
     let isRead: Bool
+
+    var id: String { rawNotification.id }
+
+    init(_ notification: USaintReceivedNotification) {
+        rawNotification = notification
+        title = notification.title
+        subtitle = notification.subtitle
+        time = notification.sentAt.relativeNotificationTimeText
+        badge = NotificationBadge(notification)
+        isRead = notification.isRead
+    }
 }
 
 private struct NotificationBadge {
@@ -415,6 +467,48 @@ private struct NotificationBadge {
     let backgroundColor: Color
     let borderColor: Color
     let hasBorder: Bool
+
+    init(
+        title: String,
+        foregroundColor: Color,
+        backgroundColor: Color,
+        borderColor: Color,
+        hasBorder: Bool
+    ) {
+        self.title = title
+        self.foregroundColor = foregroundColor
+        self.backgroundColor = backgroundColor
+        self.borderColor = borderColor
+        self.hasBorder = hasBorder
+    }
+
+    init?(_ notification: USaintReceivedNotification) {
+        if let priority = notification.priority, !priority.isEmpty {
+            switch priority {
+            case "P0":
+                self = .urgent(priority)
+            case "P1":
+                self = .warning(priority)
+            default:
+                self = .neutral(priority)
+            }
+            return
+        }
+
+        guard let pushType = notification.pushType, !pushType.isEmpty else {
+            return nil
+        }
+
+        if pushType.contains("이머전시") {
+            self = .urgent("긴급")
+        } else if pushType.contains("경고") {
+            self = .warning("경고")
+        } else if pushType.contains("미발송") {
+            self = .neutral("차단")
+        } else {
+            self = .neutral("안내")
+        }
+    }
 
     static func urgent(_ title: String) -> Self {
         Self(
@@ -447,104 +541,82 @@ private struct NotificationBadge {
     }
 }
 
-private enum NotificationSampleData {
-    static let sections: [NotificationSection] = [
-        NotificationSection(
-            title: "오늘",
-            notifications: [
-                NotificationItem(
-                    title: "내 자리 - B-12",
-                    subtitle: "채플 입장 시간 · 17:00 시작 · 입구 좌측으로 입장",
-                    time: "5분 전",
-                    badge: nil,
-                    category: .classNotice,
-                    isRead: false
-                ),
-                NotificationItem(
-                    title: "데이터베이스 과제 마감 D-1",
-                    subtitle: "오늘 자정 마감 · 아직 제출 전이에요",
-                    time: "1시간 전",
-                    badge: .urgent("D-1"),
-                    category: .classNotice,
-                    isRead: false
-                ),
-                NotificationItem(
-                    title: "수강신청 알림",
-                    subtitle: "2025-2학기 수강신청이 D-2 남았어요",
-                    time: "2시간 전",
-                    badge: nil,
-                    category: .academic,
-                    isRead: false
-                )
-            ]
-        ),
-        NotificationSection(
-            title: "이번 주",
-            notifications: [
-                NotificationItem(
-                    title: "비전채플 11회차",
-                    subtitle: "내 자리 B-12",
-                    time: "5/8 17:00",
-                    badge: .neutral("내일"),
-                    category: .classNotice,
-                    isRead: false
-                ),
-                NotificationItem(
-                    title: "데이터베이스 중간고사",
-                    subtitle: "형남공학관 308호",
-                    time: "5/20",
-                    badge: .neutral("D-5"),
-                    category: .classNotice,
-                    isRead: false
-                ),
-                NotificationItem(
-                    title: "운영체제 과제 2 안내",
-                    subtitle: "5월 12일 마감",
-                    time: "5/6",
-                    badge: nil,
-                    category: .classNotice,
-                    isRead: false
-                ),
-                NotificationItem(
-                    title: "학과 사무실 안내",
-                    subtitle: "휴학 신청 마감 D-7",
-                    time: "5/5",
-                    badge: nil,
-                    category: .academic,
-                    isRead: false
-                ),
-                NotificationItem(
-                    title: "성적장학금 신청 안내",
-                    subtitle: "신청 기간 시작",
-                    time: "5/4",
-                    badge: nil,
-                    category: .academic,
-                    isRead: false
-                )
-            ]
-        ),
-        NotificationSection(
-            title: "이전",
-            notifications: [
-                NotificationItem(
-                    title: "3월 학사일정 안내",
-                    subtitle: nil,
-                    time: "3일 전",
-                    badge: nil,
-                    category: .academic,
-                    isRead: true
-                ),
-                NotificationItem(
-                    title: "전산 시스템 점검 안내",
-                    subtitle: nil,
-                    time: "4월 25일",
-                    badge: nil,
-                    category: .academic,
-                    isRead: true
-                )
-            ]
-        )
-    ]
+private extension USaintReceivedNotification {
+    var notificationCategory: NotificationCategory {
+        switch domain {
+        case "과제", "시간표", "채플", "강의자료", "출석경고70", "출석경고75", "출석F확정":
+            .classNotice
+        default:
+            .academic
+        }
+    }
+
+    var notificationRoute: USaintNotificationRoute? {
+        if let route,
+           let notificationRoute = USaintNotificationRoute(rawValue: route) {
+            return notificationRoute
+        }
+
+        if domain == "성적" || category?.contains("성적") == true {
+            return .currentSemesterGrades
+        }
+
+        return .notification
+    }
+
+    var subtitle: String? {
+        if let body, !body.isEmpty {
+            return body
+        }
+
+        return [domain, category]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: " · ")
+            .nilIfEmpty
+    }
+
+    var sectionTitle: String {
+        let calendar = Calendar.current
+        if calendar.isDateInToday(sentAt) {
+            return "오늘"
+        }
+
+        if let days = calendar.dateComponents([.day], from: calendar.startOfDay(for: sentAt), to: calendar.startOfDay(for: Date())).day,
+           days < 7 {
+            return "이번 주"
+        }
+
+        return "이전"
+    }
+}
+
+private extension Date {
+    var relativeNotificationTimeText: String {
+        let interval = max(0, Date().timeIntervalSince(self))
+        if interval < 60 {
+            return "방금"
+        }
+
+        if interval < 60 * 60 {
+            return "\(Int(interval / 60))분 전"
+        }
+
+        if interval < 24 * 60 * 60 {
+            return "\(Int(interval / 60 / 60))시간 전"
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M/d HH:mm"
+        return formatter.string(from: self)
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
 }
 
 #Preview {

--- a/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/Core/SettingReducer.swift
@@ -33,6 +33,7 @@ struct SettingReducer {
         case syncPushAuthorizationResponse(Result<Bool, Error>)
         case pushAuthorizationResponse(Result<Bool, Error>)
         case requestPushAuthorizationResponse(Result<Bool, Error>)
+        case notificationCategoryToggled(USaintNotificationCategory, Bool)
         case termsOfServiceButtonTapped
         case privacyPolicyButtonTapped
         case alert(PresentationAction<Alert>)
@@ -44,6 +45,7 @@ struct SettingReducer {
     }
 
     @Dependency(\.localNotificationClient) var localNotificationClient
+    @Dependency(\.remoteNotificationClient) var remoteNotificationClient
     @Dependency(\.studentClient) var studentClient
     @Dependency(\.gradeClient) var gradeClient
     @Dependency(\.chapelClient) var chapelClient
@@ -57,7 +59,9 @@ struct SettingReducer {
                 if let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
                     state.appVersion = currentVersion
                 }
-                return .none
+                return .run { _ in
+                    await remoteNotificationClient.syncTopicSubscriptions()
+                }
             case .backButtonTapped:
                 return .run { _ in
                     await dismiss()
@@ -91,10 +95,14 @@ struct SettingReducer {
             case .togglePushAuthorization(false):
                 state.$permission.withLock { $0 = false }
                 YDSToast(TextLiteral.SettingReducer.pushAuthorizationDeniedToast, haptic: .success)
-                return .none
+                return .run { _ in
+                    await remoteNotificationClient.syncTopicSubscriptions()
+                }
             case .syncPushAuthorizationResponse(.success(let granted)):
                 state.$permission.withLock { $0 = granted }
-                return .none
+                return .run { _ in
+                    await remoteNotificationClient.syncTopicSubscriptions()
+                }
             case .syncPushAuthorizationResponse(.failure(let error)):
                 debugPrint("Setting Reducer: SyncPushAuthorization Error - \(error)")
                 return .none
@@ -120,7 +128,12 @@ struct SettingReducer {
                 } else {
                     YDSToast(TextLiteral.SettingReducer.pushAuthorizationAllowedToast, haptic: .success)
                 }
-                return .none
+                return .run { _ in
+                    if granted {
+                        await remoteNotificationClient.registerDeviceIfAuthorized()
+                    }
+                    await remoteNotificationClient.syncTopicSubscriptions()
+                }
             case .requestPushAuthorizationResponse(.success(let granted)):
                 if !granted {
                     if let url = URL(string: UIApplication.openSettingsURLString) {
@@ -132,6 +145,10 @@ struct SettingReducer {
                     }
                 }
                 return .none
+            case .notificationCategoryToggled(let category, let isEnabled):
+                return .run { _ in
+                    await remoteNotificationClient.updateTopicSubscription(category, isEnabled)
+                }
             case .alert(.presented(.configurePushAuthorizationTapped)):
                 debugPrint("alert permission")
                 return .run { send in

--- a/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
+++ b/Soomsil-USaint/Application/Feature/Setting/View/SettingView.swift
@@ -23,17 +23,21 @@ struct SettingView: View {
                 .padding(.bottom, 8)
 
             SettingList(
-                appVersion: store.appVersion
-            ) { tappedItem in
-                switch tappedItem {
-                case .logout:
-                    store.send(.logoutButtonTapped)
-                case .termsOfService:
-                    store.send(.termsOfServiceButtonTapped)
-                case .privacyPolicy:
-                    store.send(.privacyPolicyButtonTapped)
+                appVersion: store.appVersion,
+                listItemTapped: { tappedItem in
+                    switch tappedItem {
+                    case .logout:
+                        store.send(.logoutButtonTapped)
+                    case .termsOfService:
+                        store.send(.termsOfServiceButtonTapped)
+                    case .privacyPolicy:
+                        store.send(.privacyPolicyButtonTapped)
+                    }
+                },
+                notificationToggleChanged: { category, isEnabled in
+                    store.send(.notificationCategoryToggled(category, isEnabled))
                 }
-            }
+            )
         }
         .registerYDSToast()
         .alert(
@@ -49,6 +53,7 @@ struct SettingView: View {
     struct SettingList: View {
         let appVersion: String
         let listItemTapped: (listItem) -> Void
+        let notificationToggleChanged: (USaintNotificationCategory, Bool) -> Void
         @AppStorage("gradeAnnouncementNotificationEnabled") private var isGradeNotificationEnabled = true
         @AppStorage("chapelNotificationEnabled") private var isCampusNotificationEnabled = true
         
@@ -72,12 +77,16 @@ struct SettingView: View {
                         RowView(
                             text: TextLiteral.SettingView.gradeNotificationTitle,
                             rightItem: .toggle(isPushAuthorizationEnabled: $isGradeNotificationEnabled),
-                            action: {}
+                            action: {
+                                notificationToggleChanged(.gradeAnnouncement, isGradeNotificationEnabled)
+                            }
                         ),
                         RowView(
                             text: TextLiteral.SettingView.campusNotificationTitle,
                             rightItem: .toggle(isPushAuthorizationEnabled: $isCampusNotificationEnabled),
-                            action: {}
+                            action: {
+                                notificationToggleChanged(.chapel, isCampusNotificationEnabled)
+                            }
                         )
                     ])
                 

--- a/Soomsil-USaint/Application/Rusaint_iOSApp.swift
+++ b/Soomsil-USaint/Application/Rusaint_iOSApp.swift
@@ -11,20 +11,50 @@ import UserNotifications
 
 import ComposableArchitecture
 import FirebaseCore
+import FirebaseMessaging
 import Rusaint
 import Mixpanel
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         FirebaseApp.configure()
+        Messaging.messaging().delegate = self
         UNUserNotificationCenter.current().delegate = self
         registerNotificationCategories()
+        Task {
+            await RemoteNotificationClient.liveValue.registerDeviceIfAuthorized()
+        }
         if let token = Bundle.main.object(forInfoDictionaryKey: "MIXPANEL_TEAM_TOKEN") as? String {
             Mixpanel.initialize(token: "4cb8a3b1aabf9715a4db3005904a744d", trackAutomaticEvents: false)
         } else {
             assertionFailure("Mixpanel 토큰을 불러올 수 없습니다.")
         }
         return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        Messaging.messaging().apnsToken = deviceToken
+        Task {
+            await RemoteNotificationClient.liveValue.refreshRegistrationToken()
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        debugPrint("APNs registration failed: \(error)")
+    }
+
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        completionHandler(.noData)
     }
 
     private func registerNotificationCategories() {
@@ -90,7 +120,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        [.banner, .list, .sound]
+        guard shouldPresentNotification(notification) else {
+            return []
+        }
+
+        return [.banner, .list, .sound]
     }
 
     func userNotificationCenter(
@@ -108,15 +142,50 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             break
         }
 
-        if let route = response.notification.request.content.userInfo[NotificationUserInfoKey.route] as? String {
-            UserDefaults.standard.set(route, forKey: NotificationStorageKey.pendingRoute)
+        let userInfo = normalizedUserInfo(from: response.notification.request.content.userInfo)
+
+        if let route = USaintNotificationRoute(userInfo: userInfo) {
+            UserDefaults.standard.set(route.rawValue, forKey: NotificationStorageKey.pendingRoute)
         }
 
         NotificationCenter.default.post(
             name: .usaintNotificationOpened,
             object: nil,
-            userInfo: response.notification.request.content.userInfo
+            userInfo: userInfo
         )
+    }
+
+    private func shouldPresentNotification(_ notification: UNNotification) -> Bool {
+        guard USaintNotificationCategory.isPushEnabledInUserDefaults else {
+            return false
+        }
+
+        guard let category = USaintNotificationCategory(userInfo: notification.request.content.userInfo) else {
+            return true
+        }
+
+        return category.isEnabledInUserDefaults
+    }
+
+    private func normalizedUserInfo(from userInfo: [AnyHashable: Any]) -> [AnyHashable: Any] {
+        var normalizedUserInfo = userInfo
+
+        if let category = USaintNotificationCategory(userInfo: normalizedUserInfo) {
+            normalizedUserInfo[NotificationUserInfoKey.category] = category.rawValue
+            if let routeValue = normalizedUserInfo[NotificationUserInfoKey.route] as? String,
+               let route = USaintNotificationRoute(remoteValue: routeValue) {
+                normalizedUserInfo[NotificationUserInfoKey.route] = route.rawValue
+            } else {
+                normalizedUserInfo[NotificationUserInfoKey.route] = category.defaultRoute.rawValue
+            }
+            return normalizedUserInfo
+        }
+
+        if let route = USaintNotificationRoute(userInfo: normalizedUserInfo) {
+            normalizedUserInfo[NotificationUserInfoKey.route] = route.rawValue
+        }
+
+        return normalizedUserInfo
     }
 
     private func scheduleSnoozedNotification(
@@ -140,6 +209,14 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         )
 
         try? await UNUserNotificationCenter.current().add(request)
+    }
+}
+
+extension AppDelegate: MessagingDelegate {
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        Task {
+            await RemoteNotificationClient.liveValue.handleRegistrationToken(fcmToken)
+        }
     }
 }
 

--- a/Soomsil-USaint/Application/Rusaint_iOSApp.swift
+++ b/Soomsil-USaint/Application/Rusaint_iOSApp.swift
@@ -54,7 +54,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         didReceiveRemoteNotification userInfo: [AnyHashable: Any],
         fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
     ) {
-        completionHandler(.noData)
+        USaintReceivedNotificationStore.store(userInfo: userInfo)
+        completionHandler(.newData)
     }
 
     private func registerNotificationCategories() {
@@ -124,6 +125,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             return []
         }
 
+        USaintReceivedNotificationStore.store(notification)
         return [.banner, .list, .sound]
     }
 
@@ -131,6 +133,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {
+        USaintReceivedNotificationStore.store(response.notification, isRead: true)
+
         switch response.actionIdentifier {
         case NotificationActionIdentifier.snoozeChapel:
             await scheduleSnoozedNotification(from: response, seconds: 15 * 60)
@@ -175,6 +179,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             if let routeValue = normalizedUserInfo[NotificationUserInfoKey.route] as? String,
                let route = USaintNotificationRoute(remoteValue: routeValue) {
                 normalizedUserInfo[NotificationUserInfoKey.route] = route.rawValue
+            } else if let deeplinkValue = normalizedUserInfo[NotificationUserInfoKey.deeplink] as? String,
+                      let route = USaintNotificationRoute(remoteValue: deeplinkValue) {
+                normalizedUserInfo[NotificationUserInfoKey.route] = route.rawValue
             } else {
                 normalizedUserInfo[NotificationUserInfoKey.route] = category.defaultRoute.rawValue
             }
@@ -183,6 +190,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
         if let route = USaintNotificationRoute(userInfo: normalizedUserInfo) {
             normalizedUserInfo[NotificationUserInfoKey.route] = route.rawValue
+        } else {
+            normalizedUserInfo[NotificationUserInfoKey.route] = USaintNotificationRoute.notification.rawValue
         }
 
         return normalizedUserInfo

--- a/Soomsil-USaint/Data/Client/AlarmBackend/AlarmBackendClient.swift
+++ b/Soomsil-USaint/Data/Client/AlarmBackend/AlarmBackendClient.swift
@@ -1,0 +1,119 @@
+//
+//  AlarmBackendClient.swift
+//  Soomsil-USaint
+//
+
+import Foundation
+
+import ComposableArchitecture
+
+struct AlarmBackendClient {
+    var registerDevice: @Sendable (_ fcmToken: String) async throws -> Void
+    var registerStoredDevice: @Sendable () async throws -> Void
+}
+
+extension DependencyValues {
+    var alarmBackendClient: AlarmBackendClient {
+        get { self[AlarmBackendClient.self] }
+        set { self[AlarmBackendClient.self] = newValue }
+    }
+}
+
+extension AlarmBackendClient: DependencyKey {
+    static let liveValue: AlarmBackendClient = {
+        let baseURL = URL(string: "https://usaint-alarm-backend-production.up.railway.app")!
+        let session = URLSession.shared
+        let encoder = JSONEncoder()
+
+        return Self(
+            registerDevice: { fcmToken in
+                try await performRegisterDevice(
+                    fcmToken: fcmToken,
+                    baseURL: baseURL,
+                    session: session,
+                    encoder: encoder
+                )
+            },
+            registerStoredDevice: {
+                guard let fcmToken = UserDefaults.standard.string(forKey: RemoteNotificationStorageKey.fcmToken) else {
+                    return
+                }
+
+                try await performRegisterDevice(
+                    fcmToken: fcmToken,
+                    baseURL: baseURL,
+                    session: session,
+                    encoder: encoder
+                )
+            }
+        )
+    }()
+
+    static let previewValue: AlarmBackendClient = Self(
+        registerDevice: { _ in },
+        registerStoredDevice: {}
+    )
+
+    static let testValue: AlarmBackendClient = previewValue
+}
+
+private enum AlarmBackendError: Error {
+    case missingStudentID
+    case invalidResponse
+    case requestFailed(Int)
+}
+
+private struct DeviceRegisterRequest: Encodable {
+    let ssuId: String
+    let fcmToken: String
+    let platform: String
+    let appVersion: String?
+}
+
+private func performRegisterDevice(
+    fcmToken: String,
+    baseURL: URL,
+    session: URLSession,
+    encoder: JSONEncoder
+) async throws {
+    guard let ssuId = StudentClient.keychain["saintID"], !ssuId.isEmpty else {
+        throw AlarmBackendError.missingStudentID
+    }
+
+    let requestBody = DeviceRegisterRequest(
+        ssuId: ssuId,
+        fcmToken: fcmToken,
+        platform: "IOS",
+        appVersion: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    )
+
+    try await sendJSON(
+        requestBody,
+        path: "/api/v1/devices",
+        baseURL: baseURL,
+        session: session,
+        encoder: encoder
+    )
+}
+
+private func sendJSON<T: Encodable>(
+    _ body: T,
+    path: String,
+    baseURL: URL,
+    session: URLSession,
+    encoder: JSONEncoder
+) async throws {
+    var request = URLRequest(url: baseURL.appendingPathComponent(path))
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try encoder.encode(body)
+
+    let (_, response) = try await session.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse else {
+        throw AlarmBackendError.invalidResponse
+    }
+
+    guard (200..<300).contains(httpResponse.statusCode) else {
+        throw AlarmBackendError.requestFailed(httpResponse.statusCode)
+    }
+}

--- a/Soomsil-USaint/Data/Client/Firebase/RemoteNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/Firebase/RemoteNotificationClient.swift
@@ -1,0 +1,125 @@
+//
+//  RemoteNotificationClient.swift
+//  Soomsil-USaint
+//
+
+import Foundation
+import UIKit
+import UserNotifications
+
+import ComposableArchitecture
+import FirebaseMessaging
+
+struct RemoteNotificationClient {
+    var registerDeviceIfAuthorized: @Sendable () async -> Void
+    var syncTopicSubscriptions: @Sendable () async -> Void
+    var updateTopicSubscription: @Sendable (USaintNotificationCategory, Bool) async -> Void
+    var refreshRegistrationToken: @Sendable () async -> Void
+    var handleRegistrationToken: @Sendable (String?) async -> Void
+}
+
+extension DependencyValues {
+    var remoteNotificationClient: RemoteNotificationClient {
+        get { self[RemoteNotificationClient.self] }
+        set { self[RemoteNotificationClient.self] = newValue }
+    }
+}
+
+extension RemoteNotificationClient: DependencyKey {
+    static let liveValue: RemoteNotificationClient = Self(
+        registerDeviceIfAuthorized: {
+            await registerRemoteNotificationsIfAuthorized()
+        },
+        syncTopicSubscriptions: {
+            await syncFCMTopicSubscriptions()
+        },
+        updateTopicSubscription: { category, isEnabled in
+            UserDefaults.standard.set(isEnabled, forKey: category.userDefaultsKey)
+            await syncFCMTopicSubscriptions()
+        },
+        refreshRegistrationToken: {
+            await refreshFCMRegistrationToken()
+        },
+        handleRegistrationToken: { token in
+            await handleFCMRegistrationToken(token)
+        }
+    )
+
+    static let previewValue: RemoteNotificationClient = Self(
+        registerDeviceIfAuthorized: {},
+        syncTopicSubscriptions: {},
+        updateTopicSubscription: { _, _ in },
+        refreshRegistrationToken: {},
+        handleRegistrationToken: { _ in }
+    )
+
+    static let testValue: RemoteNotificationClient = previewValue
+}
+
+enum RemoteNotificationStorageKey {
+    static let fcmToken = "fcmRegistrationToken"
+}
+
+@MainActor
+private func registerRemoteNotificationsIfAuthorized() async {
+    let settings = await UNUserNotificationCenter.current().notificationSettings()
+    guard settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional else {
+        await syncFCMTopicSubscriptions()
+        return
+    }
+
+    UIApplication.shared.registerForRemoteNotifications()
+    await refreshFCMRegistrationToken()
+    await syncFCMTopicSubscriptions()
+}
+
+private func syncFCMTopicSubscriptions() async {
+    let settings = await UNUserNotificationCenter.current().notificationSettings()
+    let canReceivePush = (settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional)
+        && USaintNotificationCategory.isPushEnabledInUserDefaults
+
+    for category in USaintNotificationCategory.allCases {
+        let shouldSubscribe = canReceivePush && category.isEnabledInUserDefaults
+        await setFCMSubscription(shouldSubscribe, topic: category.fcmTopic)
+    }
+}
+
+private func refreshFCMRegistrationToken() async {
+    await withCheckedContinuation { continuation in
+        Messaging.messaging().token { token, error in
+            if let error {
+                debugPrint("FCM registration token refresh failed: \(error)")
+            }
+            Task {
+                await handleFCMRegistrationToken(token)
+                continuation.resume()
+            }
+        }
+    }
+}
+
+private func handleFCMRegistrationToken(_ token: String?) async {
+    guard let token, !token.isEmpty else {
+        return
+    }
+
+    UserDefaults.standard.set(token, forKey: RemoteNotificationStorageKey.fcmToken)
+    await syncFCMTopicSubscriptions()
+}
+
+private func setFCMSubscription(_ shouldSubscribe: Bool, topic: String) async {
+    await withCheckedContinuation { continuation in
+        let completion: @Sendable (Error?) -> Void = { error in
+            if let error {
+                debugPrint("FCM topic \(shouldSubscribe ? "subscribe" : "unsubscribe") failed: \(topic), \(error)")
+            }
+            continuation.resume()
+        }
+
+        if shouldSubscribe {
+            Messaging.messaging().subscribe(toTopic: topic, completion: completion)
+        } else {
+            Messaging.messaging().unsubscribe(fromTopic: topic, completion: completion)
+        }
+    }
+}

--- a/Soomsil-USaint/Data/Client/Firebase/RemoteNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/Firebase/RemoteNotificationClient.swift
@@ -69,11 +69,17 @@ private func registerRemoteNotificationsIfAuthorized() async {
     }
 
     UIApplication.shared.registerForRemoteNotifications()
-    await refreshFCMRegistrationToken()
-    await syncFCMTopicSubscriptions()
+    if Messaging.messaging().apnsToken != nil {
+        await refreshFCMRegistrationToken()
+        await syncFCMTopicSubscriptions()
+    }
 }
 
 private func syncFCMTopicSubscriptions() async {
+    guard await hasAPNSToken() else {
+        return
+    }
+
     let settings = await UNUserNotificationCenter.current().notificationSettings()
     let canReceivePush = (settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional)
         && USaintNotificationCategory.isPushEnabledInUserDefaults
@@ -85,6 +91,10 @@ private func syncFCMTopicSubscriptions() async {
 }
 
 private func refreshFCMRegistrationToken() async {
+    guard await hasAPNSToken() else {
+        return
+    }
+
     await withCheckedContinuation { continuation in
         Messaging.messaging().token { token, error in
             if let error {
@@ -105,6 +115,11 @@ private func handleFCMRegistrationToken(_ token: String?) async {
 
     UserDefaults.standard.set(token, forKey: RemoteNotificationStorageKey.fcmToken)
     await syncFCMTopicSubscriptions()
+}
+
+@MainActor
+private func hasAPNSToken() -> Bool {
+    Messaging.messaging().apnsToken != nil
 }
 
 private func setFCMSubscription(_ shouldSubscribe: Bool, topic: String) async {

--- a/Soomsil-USaint/Data/Client/Firebase/RemoteNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/Firebase/RemoteNotificationClient.swift
@@ -26,24 +26,38 @@ extension DependencyValues {
 }
 
 extension RemoteNotificationClient: DependencyKey {
-    static let liveValue: RemoteNotificationClient = Self(
-        registerDeviceIfAuthorized: {
-            await registerRemoteNotificationsIfAuthorized()
-        },
-        syncTopicSubscriptions: {
-            await syncFCMTopicSubscriptions()
-        },
-        updateTopicSubscription: { category, isEnabled in
-            UserDefaults.standard.set(isEnabled, forKey: category.userDefaultsKey)
-            await syncFCMTopicSubscriptions()
-        },
-        refreshRegistrationToken: {
-            await refreshFCMRegistrationToken()
-        },
-        handleRegistrationToken: { token in
-            await handleFCMRegistrationToken(token)
-        }
-    )
+    static let liveValue: RemoteNotificationClient = {
+        @Dependency(\.alarmBackendClient) var alarmBackendClient
+
+        return Self(
+            registerDeviceIfAuthorized: {
+                await registerRemoteNotificationsIfAuthorized()
+            },
+            syncTopicSubscriptions: {
+                await syncFCMTopicSubscriptions()
+            },
+            updateTopicSubscription: { category, isEnabled in
+                UserDefaults.standard.set(isEnabled, forKey: category.userDefaultsKey)
+                await syncFCMTopicSubscriptions()
+            },
+            refreshRegistrationToken: {
+                await refreshFCMRegistrationToken()
+            },
+            handleRegistrationToken: { token in
+                await handleFCMRegistrationToken(token)
+
+                guard let token, !token.isEmpty else {
+                    return
+                }
+
+                do {
+                    try await alarmBackendClient.registerDevice(token)
+                } catch {
+                    debugPrint("Alarm backend device registration failed: \(error)")
+                }
+            }
+        )
+    }()
 
     static let previewValue: RemoteNotificationClient = Self(
         registerDeviceIfAuthorized: {},

--- a/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
+import UIKit
 import UserNotifications
 
 import ComposableArchitecture
 
-enum USaintNotificationCategory: String, Sendable {
+enum USaintNotificationCategory: String, CaseIterable, Sendable {
     case courseRegistration
     case assignmentDeadline
     case gradeAnnouncement
@@ -39,6 +40,103 @@ enum USaintNotificationCategory: String, Sendable {
         case .courseRegistration, .assignmentDeadline, .gradeAnnouncement, .chapel:
             true
         }
+    }
+}
+
+extension USaintNotificationCategory {
+    static var isPushEnabledInUserDefaults: Bool {
+        if UserDefaults.standard.object(forKey: "permission") == nil {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: "permission")
+    }
+
+    var isEnabledInUserDefaults: Bool {
+        if UserDefaults.standard.object(forKey: userDefaultsKey) == nil {
+            return defaultEnabled
+        }
+        return UserDefaults.standard.bool(forKey: userDefaultsKey)
+    }
+
+    var fcmTopic: String {
+        switch self {
+        case .courseRegistration:
+            "usaint_course_registration"
+        case .assignmentDeadline:
+            "usaint_assignment_deadline"
+        case .gradeAnnouncement:
+            "usaint_grade_announcement"
+        case .chapel:
+            "usaint_chapel"
+        case .marketing:
+            "usaint_marketing"
+        }
+    }
+
+    var defaultRoute: USaintNotificationRoute {
+        switch self {
+        case .chapel:
+            .chapel
+        case .courseRegistration, .assignmentDeadline, .gradeAnnouncement, .marketing:
+            .notification
+        }
+    }
+
+    init?(remoteValue: String) {
+        let normalizedValue = remoteValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+
+        switch normalizedValue {
+        case Self.courseRegistration.rawValue.lowercased(),
+            "course_registration",
+            "course",
+            "수강",
+            "수강신청":
+            self = .courseRegistration
+        case Self.assignmentDeadline.rawValue.lowercased(),
+            "assignment_deadline",
+            "assignment",
+            "assignments",
+            "과제":
+            self = .assignmentDeadline
+        case Self.gradeAnnouncement.rawValue.lowercased(),
+            "grade_announcement",
+            "grade",
+            "grades",
+            "성적":
+            self = .gradeAnnouncement
+        case Self.chapel.rawValue.lowercased(),
+            "채플":
+            self = .chapel
+        case Self.marketing.rawValue.lowercased(),
+            "event",
+            "events",
+            "마케팅",
+            "이벤트":
+            self = .marketing
+        default:
+            return nil
+        }
+    }
+
+    init?(userInfo: [AnyHashable: Any]) {
+        for key in [
+            NotificationUserInfoKey.category,
+            "notification_category",
+            "notificationCategory",
+            "domain",
+            "type"
+        ] {
+            if let value = userInfo[key] as? String,
+               let category = USaintNotificationCategory(remoteValue: value) {
+                self = category
+                return
+            }
+        }
+        return nil
     }
 }
 
@@ -120,8 +218,16 @@ extension DependencyValues {
 extension LocalNotificationClient: DependencyKey {
     static let liveValue: LocalNotificationClient = Self(
         requestPushAuthorization: {
-            return try await UNUserNotificationCenter.current()
+            let granted = try await UNUserNotificationCenter.current()
                 .requestAuthorization(options: [.alert, .badge, .sound])
+
+            if granted {
+                await MainActor.run {
+                    UIApplication.shared.registerForRemoteNotifications()
+                }
+            }
+
+            return granted
         }, getPushAuthorizationStatus: {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             return (settings.authorizationStatus == .authorized) || (settings.authorizationStatus == .provisional)
@@ -159,26 +265,12 @@ extension LocalNotificationClient: DependencyKey {
     static let testValue: LocalNotificationClient = previewValue
 }
 
-private func isPushEnabled() -> Bool {
-    if UserDefaults.standard.object(forKey: "permission") == nil {
-        return true
-    }
-    return UserDefaults.standard.bool(forKey: "permission")
-}
-
-private func isCategoryEnabled(_ category: USaintNotificationCategory) -> Bool {
-    if UserDefaults.standard.object(forKey: category.userDefaultsKey) == nil {
-        return category.defaultEnabled
-    }
-    return UserDefaults.standard.bool(forKey: category.userDefaultsKey)
-}
-
 private func scheduleLocalNotification(_ payload: USaintNotificationPayload) async throws {
     let settings = await UNUserNotificationCenter.current().notificationSettings()
 
     guard (settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional),
-          isPushEnabled(),
-          isCategoryEnabled(payload.category) else {
+          USaintNotificationCategory.isPushEnabledInUserDefaults,
+          payload.category.isEnabledInUserDefaults else {
         return
     }
 

--- a/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
@@ -108,7 +108,11 @@ extension USaintNotificationCategory {
             "grade_announcement",
             "grade",
             "grades",
-            "성적":
+            "성적",
+            "성적공개",
+            "과목별성적공개",
+            "최종성적공개",
+            "계절성적공개":
             self = .gradeAnnouncement
         case Self.chapel.rawValue.lowercased(),
             "채플":

--- a/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
+++ b/Soomsil-USaint/Data/Client/LocalNotification/LocalNotificationClient.swift
@@ -75,9 +75,11 @@ extension USaintNotificationCategory {
 
     var defaultRoute: USaintNotificationRoute {
         switch self {
+        case .gradeAnnouncement:
+            .currentSemesterGrades
         case .chapel:
             .chapel
-        case .courseRegistration, .assignmentDeadline, .gradeAnnouncement, .marketing:
+        case .courseRegistration, .assignmentDeadline, .marketing:
             .notification
         }
     }
@@ -142,6 +144,7 @@ extension USaintNotificationCategory {
 
 enum USaintNotificationRoute: String, Sendable {
     case notification
+    case currentSemesterGrades
     case chapel
 }
 

--- a/Soomsil-USaint/Data/Client/NotificationStorage/ReceivedNotificationStore.swift
+++ b/Soomsil-USaint/Data/Client/NotificationStorage/ReceivedNotificationStore.swift
@@ -1,0 +1,376 @@
+//
+//  ReceivedNotificationStore.swift
+//  Soomsil-USaint
+//
+
+import Foundation
+import UserNotifications
+
+extension Notification.Name {
+    static let usaintReceivedNotificationsDidChange = Notification.Name("usaintReceivedNotificationsDidChange")
+}
+
+struct USaintReceivedNotification: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let templateId: String?
+    let domain: String?
+    let category: String?
+    let pushType: String?
+    let priority: String?
+    let title: String
+    let body: String?
+    let sentAt: Date
+    let route: String?
+    var isRead: Bool
+
+    init?(
+        notification: UNNotification,
+        isRead: Bool = false
+    ) {
+        self.init(
+            userInfo: notification.request.content.userInfo,
+            title: notification.request.content.title,
+            body: notification.request.content.body,
+            fallbackIdentifier: notification.request.identifier,
+            sentAt: notification.date,
+            isRead: isRead
+        )
+    }
+
+    init?(
+        userInfo: [AnyHashable: Any],
+        title fallbackTitle: String? = nil,
+        body fallbackBody: String? = nil,
+        fallbackIdentifier: String? = nil,
+        sentAt fallbackDate: Date = Date(),
+        isRead: Bool = false
+    ) {
+        let payloadTitle = Self.stringValue(
+            for: ["title", NotificationUserInfoKey.title, "notificationTitle"],
+            in: userInfo
+        ) ?? Self.apsAlertValue("title", in: userInfo) ?? fallbackTitle
+
+        let payloadBody = Self.stringValue(
+            for: ["body", NotificationUserInfoKey.body, "message", "notificationBody"],
+            in: userInfo
+        ) ?? Self.apsAlertValue("body", in: userInfo) ?? fallbackBody
+
+        let title = payloadTitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let body = payloadBody?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !title.isEmpty || !(body ?? "").isEmpty else {
+            return nil
+        }
+
+        let templateId = Self.stringValue(
+            for: ["templateId", "template_id", "id"],
+            in: userInfo
+        )
+        let sentAt = Self.dateValue(for: ["sentAt", "sent_at", "createdAt", "created_at"], in: userInfo) ?? fallbackDate
+        let domain = Self.stringValue(for: ["domain"], in: userInfo)
+        let category = Self.stringValue(
+            for: [NotificationUserInfoKey.category, "notification_category", "notificationCategory", "category", "type"],
+            in: userInfo
+        )
+        let route = Self.normalizedRoute(in: userInfo, domain: domain, category: category)
+        let notificationId = Self.stringValue(
+            for: ["notificationId", "notification_id", "messageId", "message_id", "gcm.message_id"],
+            in: userInfo
+        )
+        let id = notificationId
+            ?? Self.fallbackIdentifier(
+                templateId: templateId,
+                title: title,
+                body: body,
+                sentAt: sentAt
+            )
+
+        self.id = id
+        self.templateId = templateId
+        self.domain = domain
+        self.category = category
+        self.pushType = Self.stringValue(for: ["pushType", "push_type"], in: userInfo)
+        self.priority = Self.stringValue(for: ["priority"], in: userInfo)
+        self.title = title.isEmpty ? (body ?? "") : title
+        self.body = body?.isEmpty == true ? nil : body
+        self.sentAt = sentAt
+        self.route = route
+        self.isRead = isRead
+    }
+}
+
+enum USaintReceivedNotificationStore {
+    private static let storageKey = "usaintReceivedNotifications"
+    private static let retentionInterval: TimeInterval = 14 * 24 * 60 * 60
+    private static let maxStoredCount = 200
+
+    static func load() -> [USaintReceivedNotification] {
+        let notifications = normalized(loadRaw())
+        saveRaw(notifications)
+        return notifications
+    }
+
+    @discardableResult
+    static func upsert(_ notification: USaintReceivedNotification) -> [USaintReceivedNotification] {
+        upsert([notification])
+    }
+
+    @discardableResult
+    static func upsert(_ notifications: [USaintReceivedNotification]) -> [USaintReceivedNotification] {
+        guard !notifications.isEmpty else {
+            return load()
+        }
+
+        var stored = loadRaw()
+        for notification in notifications {
+            if let index = stored.firstIndex(where: { $0.id == notification.id }) {
+                let wasRead = stored[index].isRead
+                var merged = notification
+                merged.isRead = wasRead || notification.isRead
+                stored[index] = merged
+            } else {
+                stored.append(notification)
+            }
+        }
+
+        let notifications = normalized(stored)
+        saveRaw(notifications)
+        NotificationCenter.default.post(name: .usaintReceivedNotificationsDidChange, object: nil)
+        return notifications
+    }
+
+    static func markRead(_ id: String) -> [USaintReceivedNotification] {
+        var notifications = loadRaw()
+        guard let index = notifications.firstIndex(where: { $0.id == id }) else {
+            return load()
+        }
+
+        notifications[index].isRead = true
+        notifications = normalized(notifications)
+        saveRaw(notifications)
+        NotificationCenter.default.post(name: .usaintReceivedNotificationsDidChange, object: nil)
+        return notifications
+    }
+
+    static func markAllRead() -> [USaintReceivedNotification] {
+        let notifications = normalized(loadRaw().map { notification in
+            var notification = notification
+            notification.isRead = true
+            return notification
+        })
+        saveRaw(notifications)
+        NotificationCenter.default.post(name: .usaintReceivedNotificationsDidChange, object: nil)
+        return notifications
+    }
+
+    static func store(_ notification: UNNotification, isRead: Bool = false) {
+        guard let receivedNotification = USaintReceivedNotification(notification: notification, isRead: isRead) else {
+            return
+        }
+        upsert(receivedNotification)
+    }
+
+    static func store(
+        userInfo: [AnyHashable: Any],
+        title: String? = nil,
+        body: String? = nil,
+        fallbackIdentifier: String? = nil,
+        sentAt: Date = Date(),
+        isRead: Bool = false
+    ) {
+        guard let notification = USaintReceivedNotification(
+            userInfo: userInfo,
+            title: title,
+            body: body,
+            fallbackIdentifier: fallbackIdentifier,
+            sentAt: sentAt,
+            isRead: isRead
+        ) else {
+            return
+        }
+        upsert(notification)
+    }
+
+    static func mergeDeliveredNotifications() async -> [USaintReceivedNotification] {
+        let deliveredNotifications = await withCheckedContinuation { continuation in
+            UNUserNotificationCenter.current().getDeliveredNotifications { notifications in
+                continuation.resume(returning: notifications)
+            }
+        }
+
+        let notifications = deliveredNotifications.compactMap {
+            USaintReceivedNotification(notification: $0)
+        }
+
+        return upsert(notifications)
+    }
+
+    private static func loadRaw() -> [USaintReceivedNotification] {
+        guard let data = UserDefaults.standard.data(forKey: storageKey) else {
+            return []
+        }
+
+        do {
+            return try JSONDecoder().decode([USaintReceivedNotification].self, from: data)
+        } catch {
+            debugPrint("Received notification decode failed: \(error)")
+            return []
+        }
+    }
+
+    private static func saveRaw(_ notifications: [USaintReceivedNotification]) {
+        do {
+            let data = try JSONEncoder().encode(notifications)
+            UserDefaults.standard.set(data, forKey: storageKey)
+        } catch {
+            debugPrint("Received notification encode failed: \(error)")
+        }
+    }
+
+    private static func normalized(_ notifications: [USaintReceivedNotification]) -> [USaintReceivedNotification] {
+        let cutoffDate = Date().addingTimeInterval(-retentionInterval)
+        return notifications
+            .filter { $0.sentAt >= cutoffDate }
+            .sorted { $0.sentAt > $1.sentAt }
+            .prefix(maxStoredCount)
+            .map { $0 }
+    }
+}
+
+private extension USaintReceivedNotification {
+    static func stringValue(for keys: [String], in userInfo: [AnyHashable: Any]) -> String? {
+        for key in keys {
+            guard let value = userInfo[AnyHashable(key)] else {
+                continue
+            }
+
+            if let string = value as? String {
+                let trimmedString = string.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmedString.isEmpty {
+                    return trimmedString
+                }
+            }
+
+            if let number = value as? NSNumber {
+                return number.stringValue
+            }
+        }
+        return nil
+    }
+
+    static func apsAlertValue(_ key: String, in userInfo: [AnyHashable: Any]) -> String? {
+        guard let aps = dictionaryValue(userInfo[AnyHashable("aps")]) else {
+            return nil
+        }
+
+        if let alert = dictionaryValue(aps["alert"]),
+           let value = alert[key] as? String,
+           !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return value
+        }
+
+        if key == "body",
+           let value = aps["alert"] as? String,
+           !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return value
+        }
+
+        return nil
+    }
+
+    static func dateValue(for keys: [String], in userInfo: [AnyHashable: Any]) -> Date? {
+        for key in keys {
+            guard let value = userInfo[AnyHashable(key)] else {
+                continue
+            }
+
+            if let date = value as? Date {
+                return date
+            }
+
+            if let timeInterval = value as? TimeInterval {
+                return Date(timeIntervalSince1970: normalizedTimeInterval(timeInterval))
+            }
+
+            if let number = value as? NSNumber {
+                return Date(timeIntervalSince1970: normalizedTimeInterval(number.doubleValue))
+            }
+
+            if let string = value as? String {
+                if let date = iso8601Date(from: string) {
+                    return date
+                }
+
+                if let timeInterval = TimeInterval(string) {
+                    return Date(timeIntervalSince1970: normalizedTimeInterval(timeInterval))
+                }
+            }
+        }
+        return nil
+    }
+
+    static func dictionaryValue(_ value: Any?) -> [String: Any]? {
+        if let dictionary = value as? [String: Any] {
+            return dictionary
+        }
+
+        if let dictionary = value as? [AnyHashable: Any] {
+            return dictionary.reduce(into: [String: Any]()) { result, element in
+                guard let key = element.key as? String else {
+                    return
+                }
+                result[key] = element.value
+            }
+        }
+
+        return nil
+    }
+
+    static func normalizedTimeInterval(_ timeInterval: TimeInterval) -> TimeInterval {
+        timeInterval > 10_000_000_000 ? timeInterval / 1_000 : timeInterval
+    }
+
+    static func normalizedRoute(
+        in userInfo: [AnyHashable: Any],
+        domain: String?,
+        category: String?
+    ) -> String? {
+        if let routeValue = stringValue(for: [NotificationUserInfoKey.route, "deeplink", "deepLink"], in: userInfo),
+           let route = USaintNotificationRoute(remoteValue: routeValue) {
+            return route.rawValue
+        }
+
+        if domain == "성적" || category?.contains("성적") == true {
+            return USaintNotificationRoute.currentSemesterGrades.rawValue
+        }
+
+        return USaintNotificationRoute.notification.rawValue
+    }
+
+    static func fallbackIdentifier(
+        templateId: String?,
+        title: String,
+        body: String?,
+        sentAt: Date
+    ) -> String {
+        [
+            templateId,
+            title,
+            body,
+            String(Int(sentAt.timeIntervalSince1970))
+        ]
+            .compactMap { $0 }
+            .joined(separator: "|")
+    }
+
+    static func iso8601Date(from string: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: string) {
+            return date
+        }
+
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: string)
+    }
+}

--- a/Soomsil-USaint/Global/Utils/NotificationRouting.swift
+++ b/Soomsil-USaint/Global/Utils/NotificationRouting.swift
@@ -27,3 +27,51 @@ enum NotificationActionIdentifier {
     static let snoozeAssignment = "SNOOZE_ASSIGNMENT"
     static let openGrade = "OPEN_GRADE"
 }
+
+extension USaintNotificationRoute {
+    init?(remoteValue: String) {
+        let normalizedValue = remoteValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+
+        switch normalizedValue {
+        case Self.notification.rawValue,
+            "home",
+            "feed",
+            "course",
+            "course_registration",
+            "assignment",
+            "assignment_deadline",
+            "grade",
+            "grade_announcement",
+            "marketing",
+            "알림",
+            "성적",
+            "과제",
+            "수강신청":
+            self = .notification
+        case Self.chapel.rawValue,
+            "채플":
+            self = .chapel
+        default:
+            return nil
+        }
+    }
+
+    init?(userInfo: [AnyHashable: Any]) {
+        if let routeValue = userInfo[NotificationUserInfoKey.route] as? String,
+           let route = USaintNotificationRoute(remoteValue: routeValue) {
+            self = route
+            return
+        }
+
+        if let category = USaintNotificationCategory(userInfo: userInfo) {
+            self = category.defaultRoute
+            return
+        }
+
+        return nil
+    }
+}

--- a/Soomsil-USaint/Global/Utils/NotificationRouting.swift
+++ b/Soomsil-USaint/Global/Utils/NotificationRouting.swift
@@ -44,14 +44,23 @@ extension USaintNotificationRoute {
             "course_registration",
             "assignment",
             "assignment_deadline",
-            "grade",
-            "grade_announcement",
             "marketing",
             "알림",
-            "성적",
             "과제",
             "수강신청":
             self = .notification
+        case Self.currentSemesterGrades.rawValue.lowercased(),
+            "current_semester_grades",
+            "current_semester_grade",
+            "grade",
+            "grades",
+            "grade_announcement",
+            "semester_grade",
+            "semester_grades",
+            "성적",
+            "성적공개",
+            "성적_공개":
+            self = .currentSemesterGrades
         case Self.chapel.rawValue,
             "채플":
             self = .chapel

--- a/Soomsil-USaint/Global/Utils/NotificationRouting.swift
+++ b/Soomsil-USaint/Global/Utils/NotificationRouting.swift
@@ -11,7 +11,9 @@ extension Notification.Name {
 
 enum NotificationUserInfoKey {
     static let route = "route"
+    static let deeplink = "deeplink"
     static let category = "category"
+    static let domain = "domain"
     static let title = "title"
     static let body = "body"
 }
@@ -45,9 +47,15 @@ extension USaintNotificationRoute {
             "assignment",
             "assignment_deadline",
             "marketing",
+            "leave",
+            "absence",
+            "app_system",
+            "system",
             "알림",
             "과제",
-            "수강신청":
+            "수강신청",
+            "휴학",
+            "앱시스템":
             self = .notification
         case Self.currentSemesterGrades.rawValue.lowercased(),
             "current_semester_grades",
@@ -70,9 +78,24 @@ extension USaintNotificationRoute {
     }
 
     init?(userInfo: [AnyHashable: Any]) {
-        if let routeValue = userInfo[NotificationUserInfoKey.route] as? String,
-           let route = USaintNotificationRoute(remoteValue: routeValue) {
-            self = route
+        for key in [
+            NotificationUserInfoKey.route,
+            NotificationUserInfoKey.deeplink,
+            "deepLink"
+        ] {
+            if let routeValue = userInfo[key] as? String,
+               let route = USaintNotificationRoute(remoteValue: routeValue) {
+                self = route
+                return
+            }
+        }
+
+        if let domainValue = userInfo[NotificationUserInfoKey.domain] as? String {
+            if domainValue == "성적" {
+                self = .currentSemesterGrades
+            } else {
+                self = .notification
+            }
             return
         }
 

--- a/Soomsil-USaint/GoogleService-Info.plist
+++ b/Soomsil-USaint/GoogleService-Info.plist
@@ -3,17 +3,17 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyDpHLpOch4gBX2fqS313wTrQH2IUzHmlg0</string>
+	<string>AIzaSyASMyRgcraDfKH6Mm_vnxIL-UfjgzLUaps</string>
 	<key>GCM_SENDER_ID</key>
-	<string>52701294141</string>
+	<string>558854254256</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
 	<string>com.yourssu.SaintKit</string>
 	<key>PROJECT_ID</key>
-	<string>soomsil-usaint</string>
+	<string>saint-74c24</string>
 	<key>STORAGE_BUCKET</key>
-	<string>soomsil-usaint.firebasestorage.app</string>
+	<string>saint-74c24.firebasestorage.app</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -25,6 +25,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:52701294141:ios:e6a52f5369e1afd0814454</string>
+	<string>1:558854254256:ios:3c62422b270fa4bbb21575</string>
 </dict>
 </plist>

--- a/Soomsil-USaint/Soomsil-USaint.entitlements
+++ b/Soomsil-USaint/Soomsil-USaint.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/Tests/Soomsil-USaint-iOSTests/Soomsil_USaint_iOSTests.swift
+++ b/Tests/Soomsil-USaint-iOSTests/Soomsil_USaint_iOSTests.swift
@@ -1,6 +1,24 @@
 import Testing
 @testable import Soomsil_USaint_iOS
 
-@Test func example() async throws {
-    // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+@Test func notificationCategoryParsesRemoteValues() async throws {
+    #expect(USaintNotificationCategory(remoteValue: "성적") == .gradeAnnouncement)
+    #expect(USaintNotificationCategory(remoteValue: "assignment_deadline") == .assignmentDeadline)
+    #expect(USaintNotificationCategory(remoteValue: "수강신청") == .courseRegistration)
+}
+
+@Test func notificationRouteFallsBackToCategoryDefault() async throws {
+    #expect(USaintNotificationRoute(userInfo: [
+        NotificationUserInfoKey.category: "채플"
+    ]) == .chapel)
+
+    #expect(USaintNotificationRoute(userInfo: [
+        NotificationUserInfoKey.category: "과제"
+    ]) == .notification)
+}
+
+@Test func notificationCategoriesUseStableFCMTopics() async throws {
+    #expect(USaintNotificationCategory.assignmentDeadline.fcmTopic == "usaint_assignment_deadline")
+    #expect(USaintNotificationCategory.gradeAnnouncement.fcmTopic == "usaint_grade_announcement")
+    #expect(USaintNotificationCategory.chapel.fcmTopic == "usaint_chapel")
 }

--- a/Tests/Soomsil-USaint-iOSTests/Soomsil_USaint_iOSTests.swift
+++ b/Tests/Soomsil-USaint-iOSTests/Soomsil_USaint_iOSTests.swift
@@ -13,8 +13,17 @@ import Testing
     ]) == .chapel)
 
     #expect(USaintNotificationRoute(userInfo: [
+        NotificationUserInfoKey.category: "성적"
+    ]) == .currentSemesterGrades)
+
+    #expect(USaintNotificationRoute(userInfo: [
         NotificationUserInfoKey.category: "과제"
     ]) == .notification)
+}
+
+@Test func gradeNotificationRouteOpensCurrentSemesterGrades() async throws {
+    #expect(USaintNotificationRoute(remoteValue: "grade_announcement") == .currentSemesterGrades)
+    #expect(USaintNotificationRoute(remoteValue: "성적 공개") == .currentSemesterGrades)
 }
 
 @Test func notificationCategoriesUseStableFCMTopics() async throws {


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->

- [x] Firebase Messaging 기반 원격 푸시 수신 구현
- [x] APNs Push capability 및 `FirebaseMessaging` 의존성 추가
- [x] 알림 백엔드에 iOS FCM 토큰 등록 연동
- [x] FCM payload 기반 앱 내부 라우팅 연결
- [x] 수신 푸시 로컬 저장 및 알림 탭 실제 데이터 표시

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->

- 이슈 티켓 : #173
- 관련 문서 : `usaint_push_v5.xlsx`
- close: #173

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->

  ### Firebase Messaging / APNs 연동

  - 기존 FirebaseCore / RemoteConfig만 연결되어 있던 상태에서 `FirebaseMessaging` product를 앱 타깃에 추가했습니다.
  - 실제 APNs 푸시 수신을 위해 `Soomsil-USaint.entitlements`를 추가하고 `aps-environment`를 설정했습니다.
  - `AppDelegate`에서 Firebase 초기화 이후 `Messaging.messaging().delegate`를 연결했습니다.
  - APNs device token을 Firebase Messaging에 전달한 뒤 FCM registration token을 갱신하도록 처리했습니다.
  - APNs token이 아직 없는 시점에는 FCM token 조회와 topic 동기화를 건너뛰어 초기 실행 시 FCM 505 에러가 반복되지 않도록 했습니다.

  ### Firebase 프로젝트 설정 정리

  - 앱에 포함된 Firebase iOS 설정 파일을 현재 푸시 서버와 같은 Firebase 프로젝트 기준으로 맞췄습니다.
  - 앱 Bundle ID는 기존과 동일하게 `com.yourssu.SaintKit`을 유지했습니다.
  - APNs Auth Key가 업로드된 Firebase 프로젝트와 앱의 Firebase 설정이 일치해야 푸시 수신이 가능합니다.
  - Firebase Console 링크, APNs key, Key ID, FCM 토큰 같은 민감 정보는 PR 본문과 코드에 포함하지 않았습니다.

  ### 알림 백엔드 디바이스 등록

  - Android와 동일하게 앱 런타임에서 직접 호출하는 서버 API 범위를 `POST /api/v1/devices`로 제한했습니다.
  - `AlarmBackendClient`를 TCA DependencyClient 형태로 추가했습니다.
  - 서버로 등록하는 값은 아래 항목입니다.
    - `ssuId`
    - `fcmToken`
    - `platform: IOS`
    - `appVersion`
  - 앱 부팅 후 알림 권한이 허용되어 있으면 저장된 FCM 토큰을 다시 업서트하도록 했습니다.
  - FCM token이 새로 발급되거나 갱신될 때도 서버에 디바이스를 재등록합니다.
  - `/api/v1/sync/academic` 및 관리자 템플릿 API는 앱 런타임에서 호출하지 않습니다.

  ### FCM Topic 설정 동기화

  - `RemoteNotificationClient`에서 아래 역할을 담당하도록 분리했습니다.
    - 알림 권한 허용 상태에서 원격 알림 등록
    - FCM registration token refresh
    - FCM token 로컬 저장
    - 카테고리별 topic subscribe / unsubscribe
    - 전체 알림 및 개별 알림 설정에 따른 topic 동기화
  - 기존 `AppStorage` 기반 알림 설정 값을 로컬 알림과 원격 알림이 함께 사용하도록 정리했습니다.
  - 전체 푸시가 꺼져 있거나 시스템 알림 권한이 없으면 topic 구독을 해지합니다.
  - 전체 푸시가 켜져 있고 개별 카테고리 토글이 켜진 경우에만 해당 topic을 구독합니다.

  ### FCM Payload 파싱 / 라우팅 정규화

  - 서버 payload가 앱 enum rawValue와 다르게 들어와도 처리할 수 있도록 정규화했습니다.
  - `route`, `deeplink`, `deepLink`, `domain`, `category` 값을 기준으로 목적지를 계산합니다.
  - `domain == "성적"` 또는 `deeplink == "grade"` 계열 payload는 홈 탭의 이번 학기 성적 모달로 이동합니다.
  - `수강신청`, `휴학`, `앱시스템` 등 명확한 상세 화면이 없는 도메인은 알림 탭으로 fallback합니다.
  - 기존 채플 / 과제 로컬 알림 액션은 유지하면서 원격 푸시 payload만 추가로 정규화했습니다.

  ### 수신 알림 로컬 저장

  - `USaintReceivedNotification` 모델과 `USaintReceivedNotificationStore`를 추가했습니다.
  - 서버 템플릿 응답과 FCM payload에서 사용하는 공통 필드를 저장합니다.
    - `templateId`
    - `domain`
    - `category`
    - `pushType`
    - `priority`
    - `title`
    - `body`
    - `sentAt`
    - `route`
    - `isRead`
  - `notificationId` 또는 FCM message id가 있으면 이를 우선 사용하고, 없으면 `templateId + title + body + sentAt` 기반 키로 중복을 방지합니다.
  - 포그라운드 수신, 백그라운드 silent 수신, 알림 클릭 시점에 수신 알림을 로컬 저장소에 upsert합니다.
  - 알림 탭 진입 시 `UNUserNotificationCenter.getDeliveredNotifications()` 결과와 로컬 저장 데이터를 병합합니다.
  - 백엔드 payload에 `mutable-content: 1` 및 Notification Service Extension / App Group이 없으면, 앱 종료 중 도착했다가 사용자가 알림센터에서 지운 알림은 iOS 단독으로 복구할 수 없습니다.

  ### 알림 탭 실제 데이터 표시

  - 기존 `NotificationSampleData` 더미 데이터를 제거했습니다.
  - 알림 탭은 로컬 저장소와 iOS delivered notification 병합 결과를 기준으로 표시합니다.
  - 알림은 `오늘`, `이번 주`, `이전` 섹션으로 묶어 최신순으로 표시합니다.
  - `domain` 기준으로 학사 / 수업 필터에 매핑합니다.
  - `priority`와 `pushType` 값이 있으면 뱃지 스타일에 반영합니다.
  - 개별 알림 클릭 시 읽음 처리 후 payload route에 맞게 이동합니다.
  - 전체 읽음 처리는 로컬 저장소에 반영됩니다.

  ### Foreground 알림 표시 필터링

  - 앱이 포그라운드 상태일 때도 사용자 설정을 반영하도록 했습니다.
  - 전체 푸시가 꺼져 있으면 알림을 표시하지 않습니다.
  - payload에서 카테고리를 확인할 수 있는 경우 해당 카테고리 토글이 켜져 있을 때만 banner / list / sound를 표시합니다.
  - 카테고리를 알 수 없는 payload는 기존 동작과 호환되도록 표시를 허용했습니다.

## 📚 Reference
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->

- 푸시 알림 명세: `usaint_push_v5.xlsx`
- 백엔드 관리자 템플릿 API 응답은 개발 시점의 payload 파싱 기준으로만 참고했고, 앱 런타임에서는 호출하지 않습니다.

## 🔥 Test
<!-- Test -->

https://github.com/user-attachments/assets/aeede353-1ec6-4b29-9ffa-2453d20a3db1

<img width="590" height="1278" alt="IMG_9928" src="https://github.com/user-attachments/assets/30358d15-369a-4849-8358-80add17aeb3f" />

